### PR TITLE
Wire AuthnServiceProvider: config + container bindings + Authn facade

### DIFF
--- a/config/authn.php
+++ b/config/authn.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Publishable / Secret keys
+    |--------------------------------------------------------------------------
+    |
+    | The publishable key is the one you embed in browser-side code; it encodes
+    | the Frontend API host, so the JWT verifier can derive the JWKS URL
+    | from it without extra config. The secret key is server-only and signs
+    | every Backend API request.
+    |
+    */
+
+    'publishable_key' => env('AUTHN_PUBLISHABLE_KEY'),
+
+    'secret_key' => env('AUTHN_SECRET_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | API URL overrides
+    |--------------------------------------------------------------------------
+    |
+    | Both default to the production hosts (api.authn.sh / derived FAPI URL)
+    | when left blank. Set these for self-hosted deployments or when pointing
+    | a single Laravel app at a non-production environment.
+    |
+    */
+
+    'api_url' => env('AUTHN_API_URL'),
+
+    'frontend_api_url' => env('AUTHN_FRONTEND_API_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook signing
+    |--------------------------------------------------------------------------
+    |
+    | `webhook_signing_secret` is the active signing secret (whsec_…). During
+    | a rotation overlap, add the previous secret(s) to `webhook_signing_secrets`
+    | so the verifier accepts both. `webhook_tolerance` is the replay window
+    | in seconds (defaults to 5 minutes).
+    |
+    */
+
+    'webhook_signing_secret' => env('AUTHN_WEBHOOK_SECRET'),
+
+    'webhook_signing_secrets' => array_values(array_filter([
+        // 'whsec_old_xxxx',
+    ])),
+
+    'webhook_tolerance' => (int) env('AUTHN_WEBHOOK_TOLERANCE', 300),
+
+    /*
+    |--------------------------------------------------------------------------
+    | JWT verifier
+    |--------------------------------------------------------------------------
+    |
+    | The Frontend API JWKS document is cached in Laravel's cache for
+    | `jwks_cache_ttl` seconds. Leave `jwks_cache_store` null to use the
+    | default cache store, or name a specific store ("redis", "memcached", …).
+    | `allowed_clock_skew` is applied when validating exp / iat / nbf.
+    |
+    */
+
+    'jwks_cache_ttl' => (int) env('AUTHN_JWKS_CACHE_TTL', 600),
+
+    'jwks_cache_store' => env('AUTHN_JWKS_CACHE_STORE'),
+
+    'allowed_clock_skew' => (int) env('AUTHN_ALLOWED_CLOCK_SKEW', 5),
+
+];

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel;
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Resources\AllowlistIdentifiersManager;
+use Authn\Sdk\Resources\BlocklistIdentifiersManager;
+use Authn\Sdk\Resources\InstanceManager;
+use Authn\Sdk\Resources\InvitationsManager;
+use Authn\Sdk\Resources\RedirectUrlsManager;
+use Authn\Sdk\Resources\SessionsManager;
+use Authn\Sdk\Resources\UsersManager;
+use Authn\Sdk\Resources\WebhookEndpointsManager;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Http\Request;
+
+/**
+ * Single entry point used by the `Authn` facade. Lazily resolves the underlying
+ * SDK objects from the container so they're not all built unless you call them.
+ */
+class AuthnManager
+{
+    public function __construct(private readonly Container $container) {}
+
+    public function client(): Client
+    {
+        /** @var Client $client */
+        $client = $this->container->make(Client::class);
+
+        return $client;
+    }
+
+    public function tokens(): TokenVerifier
+    {
+        /** @var TokenVerifier $verifier */
+        $verifier = $this->container->make(TokenVerifier::class);
+
+        return $verifier;
+    }
+
+    public function webhooks(): SignatureVerifier
+    {
+        /** @var SignatureVerifier $verifier */
+        $verifier = $this->container->make(SignatureVerifier::class);
+
+        return $verifier;
+    }
+
+    /**
+     * Verified claims for the current request, after the AuthenticateWithAuthn
+     * middleware (SPL-3) has run. Returns null outside of an authenticated
+     * request lifecycle.
+     */
+    public function auth(): ?VerifiedClaims
+    {
+        if (! $this->container->bound('request')) {
+            return null;
+        }
+
+        $request = $this->container->make('request');
+        if (! $request instanceof Request) {
+            return null;
+        }
+
+        $claims = $request->attributes->get('authn.claims');
+
+        return $claims instanceof VerifiedClaims ? $claims : null;
+    }
+
+    public function users(): UsersManager
+    {
+        return $this->client()->users();
+    }
+
+    public function sessions(): SessionsManager
+    {
+        return $this->client()->sessions();
+    }
+
+    public function invitations(): InvitationsManager
+    {
+        return $this->client()->invitations();
+    }
+
+    public function allowlistIdentifiers(): AllowlistIdentifiersManager
+    {
+        return $this->client()->allowlistIdentifiers();
+    }
+
+    public function blocklistIdentifiers(): BlocklistIdentifiersManager
+    {
+        return $this->client()->blocklistIdentifiers();
+    }
+
+    public function redirectUrls(): RedirectUrlsManager
+    {
+        return $this->client()->redirectUrls();
+    }
+
+    public function instance(): InstanceManager
+    {
+        return $this->client()->instance();
+    }
+
+    public function webhookEndpoints(): WebhookEndpointsManager
+    {
+        return $this->client()->webhookEndpoints();
+    }
+}

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -4,23 +4,161 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Laravel;
 
+use Authn\Sdk\Client;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use Psr\SimpleCache\CacheInterface;
+use RuntimeException;
 
-/**
- * Container bindings, config publishing, middleware aliasing, and Blade directive
- * registration land in SPL-2 / SPL-3. This skeleton just makes the package
- * auto-discoverable so a fresh `composer require authn-sh/sdk-php-laravel` boots
- * cleanly in a Laravel 11 / 12 application.
- */
 class AuthnServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // SPL-2 wires Client / TokenVerifier / SignatureVerifier here.
+        $this->mergeConfigFrom($this->configPath(), 'authn');
+
+        $this->app->singleton(Client::class, $this->makeClient(...));
+        $this->app->singleton(TokenVerifier::class, $this->makeTokenVerifier(...));
+        $this->app->singleton(SignatureVerifier::class, $this->makeSignatureVerifier(...));
+
+        $this->app->singleton('authn.manager', static fn (Container $app): AuthnManager => new AuthnManager($app));
+        $this->app->alias('authn.manager', AuthnManager::class);
+
+        $this->app->alias(Client::class, 'authn.client');
+        $this->app->alias(TokenVerifier::class, 'authn.tokens');
+        $this->app->alias(SignatureVerifier::class, 'authn.webhooks');
     }
 
     public function boot(): void
     {
-        // SPL-2 publishes config/authn.php; SPL-3 registers middleware + Blade directives.
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                $this->configPath() => $this->app->configPath('authn.php'),
+            ], 'authn-config');
+        }
+    }
+
+    private function configPath(): string
+    {
+        return __DIR__ . '/../config/authn.php';
+    }
+
+    private function makeClient(Container $app): Client
+    {
+        $config = $this->config($app);
+        $secretKey = $this->stringOrNull($config->get('authn.secret_key'));
+
+        if ($secretKey === null) {
+            throw new RuntimeException(
+                'authn.sh secret key is missing — set AUTHN_SECRET_KEY in your environment.',
+            );
+        }
+
+        return new Client(
+            secretKey: $secretKey,
+            apiUrl: $this->stringOrNull($config->get('authn.api_url')),
+        );
+    }
+
+    private function makeTokenVerifier(Container $app): TokenVerifier
+    {
+        $config = $this->config($app);
+        $publishableKey = $this->stringOrNull($config->get('authn.publishable_key'));
+
+        if ($publishableKey === null) {
+            throw new RuntimeException(
+                'authn.sh publishable key is missing — set AUTHN_PUBLISHABLE_KEY in your environment.',
+            );
+        }
+
+        return new TokenVerifier(
+            publishableKey: $publishableKey,
+            frontendApiUrl: $this->stringOrNull($config->get('authn.frontend_api_url')),
+            cache: $this->resolveCache($app, $this->stringOrNull($config->get('authn.jwks_cache_store'))),
+            jwksCacheTtlSeconds: $this->intConfig($config->get('authn.jwks_cache_ttl'), 600),
+            allowedClockSkewSeconds: $this->intConfig($config->get('authn.allowed_clock_skew'), 5),
+        );
+    }
+
+    private function makeSignatureVerifier(Container $app): SignatureVerifier
+    {
+        $config = $this->config($app);
+
+        $secrets = [];
+        $primary = $this->stringOrNull($config->get('authn.webhook_signing_secret'));
+        if ($primary !== null) {
+            $secrets[] = $primary;
+        }
+
+        $rotation = $config->get('authn.webhook_signing_secrets', []);
+        if (is_array($rotation)) {
+            foreach ($rotation as $secret) {
+                if (is_string($secret) && $secret !== '') {
+                    $secrets[] = $secret;
+                }
+            }
+        }
+
+        if ($secrets === []) {
+            throw new RuntimeException(
+                'authn.sh webhook signing secret is missing — set AUTHN_WEBHOOK_SECRET in your environment.',
+            );
+        }
+
+        return new SignatureVerifier(
+            signingSecret: $secrets,
+            toleranceSeconds: $this->intConfig($config->get('authn.webhook_tolerance'), 300),
+        );
+    }
+
+    private function resolveCache(Container $app, ?string $store): CacheInterface
+    {
+        /** @var CacheFactory $factory */
+        $factory = $app->make('cache');
+
+        $repository = $store !== null ? $factory->store($store) : $factory->store();
+
+        if (! $repository instanceof CacheInterface) {
+            throw new RuntimeException(
+                'The configured cache store does not implement Psr\\SimpleCache\\CacheInterface.',
+            );
+        }
+
+        return $repository;
+    }
+
+    private function config(Container $app): ConfigRepository
+    {
+        /** @var ConfigRepository $config */
+        $config = $app->make('config');
+
+        return $config;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function intConfig(mixed $value, int $default): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '' && ctype_digit(ltrim($value, '-'))) {
+            return (int) $value;
+        }
+
+        return $default;
     }
 }

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -4,15 +4,29 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Laravel\Facades;
 
+use Authn\Sdk\Laravel\AuthnManager;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * Static-proxy facade for the authn.sh Laravel package.
  *
- * The accessor `authn.manager` is bound by AuthnServiceProvider in SPL-2; this
- * skeleton exists so the autodiscover alias `Authn` resolves to a real class
- * the moment the package is required, rather than failing at class-load time
- * because the class doesn't exist yet.
+ * Resolves to the singleton-bound `\Authn\Sdk\Laravel\AuthnManager` so calls
+ * like `Authn::client()` and `Authn::auth()` reach the manager statically.
+ *
+ * @method static \Authn\Sdk\Client client()
+ * @method static \Authn\Sdk\Tokens\TokenVerifier tokens()
+ * @method static \Authn\Sdk\Webhooks\SignatureVerifier webhooks()
+ * @method static \Authn\Sdk\Tokens\VerifiedClaims|null auth()
+ * @method static \Authn\Sdk\Resources\UsersManager users()
+ * @method static \Authn\Sdk\Resources\SessionsManager sessions()
+ * @method static \Authn\Sdk\Resources\InvitationsManager invitations()
+ * @method static \Authn\Sdk\Resources\AllowlistIdentifiersManager allowlistIdentifiers()
+ * @method static \Authn\Sdk\Resources\BlocklistIdentifiersManager blocklistIdentifiers()
+ * @method static \Authn\Sdk\Resources\RedirectUrlsManager redirectUrls()
+ * @method static \Authn\Sdk\Resources\InstanceManager instance()
+ * @method static \Authn\Sdk\Resources\WebhookEndpointsManager webhookEndpoints()
+ *
+ * @see AuthnManager
  */
 class Authn extends Facade
 {

--- a/tests/BindingsTest.php
+++ b/tests/BindingsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\AuthnManager;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+
+it('binds the BAPI Client as a singleton', function (): void {
+    $first = app(Client::class);
+    $second = app(Client::class);
+
+    expect($first)->toBeInstanceOf(Client::class)
+        ->and($first)->toBe($second);
+});
+
+it('binds the TokenVerifier as a singleton', function (): void {
+    $first = app(TokenVerifier::class);
+    $second = app(TokenVerifier::class);
+
+    expect($first)->toBeInstanceOf(TokenVerifier::class)
+        ->and($first)->toBe($second);
+});
+
+it('binds the SignatureVerifier as a singleton', function (): void {
+    $first = app(SignatureVerifier::class);
+    $second = app(SignatureVerifier::class);
+
+    expect($first)->toBeInstanceOf(SignatureVerifier::class)
+        ->and($first)->toBe($second);
+});
+
+it('binds the AuthnManager + facade accessor', function (): void {
+    /** @var AuthnManager $byKey */
+    $byKey = app('authn.manager');
+    $byClass = app(AuthnManager::class);
+
+    expect($byKey)->toBeInstanceOf(AuthnManager::class);
+    expect($byKey)->toBe($byClass);
+});
+
+it('exposes string aliases for each SDK service', function (): void {
+    /** @var Client $client */
+    $client = app('authn.client');
+    /** @var TokenVerifier $tokens */
+    $tokens = app('authn.tokens');
+    /** @var SignatureVerifier $webhooks */
+    $webhooks = app('authn.webhooks');
+
+    expect($client)->toBe(app(Client::class));
+    expect($tokens)->toBe(app(TokenVerifier::class));
+    expect($webhooks)->toBe(app(SignatureVerifier::class));
+});
+
+it('configures Client with the api_url override when provided', function (): void {
+    config()->set('authn.api_url', 'https://staging.api.authn.sh');
+
+    /** @var Client $client */
+    $client = app(Client::class);
+
+    expect($client->config()->apiUrl)->toBe('https://staging.api.authn.sh');
+});

--- a/tests/ConfigPublishTest.php
+++ b/tests/ConfigPublishTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+it('publishes config/authn.php under the authn-config tag', function (): void {
+    $target = config_path('authn.php');
+    if (File::exists($target)) {
+        File::delete($target);
+    }
+
+    Artisan::call('vendor:publish', ['--tag' => 'authn-config', '--force' => true]);
+
+    expect(File::exists($target))->toBeTrue();
+    /** @var array<string, mixed> $published */
+    $published = require $target;
+    expect($published)->toHaveKey('publishable_key')
+        ->toHaveKey('secret_key')
+        ->toHaveKey('webhook_signing_secret')
+        ->toHaveKey('jwks_cache_ttl');
+
+    File::delete($target);
+});

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Resources\InstanceManager;
+use Authn\Sdk\Resources\InvitationsManager;
+use Authn\Sdk\Resources\SessionsManager;
+use Authn\Sdk\Resources\UsersManager;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+
+it('routes core service calls through the bound AuthnManager', function (): void {
+    expect(Authn::client())->toBeInstanceOf(Client::class)
+        ->and(Authn::client())->toBe(app(Client::class));
+
+    expect(Authn::tokens())->toBeInstanceOf(TokenVerifier::class)
+        ->and(Authn::tokens())->toBe(app(TokenVerifier::class));
+
+    expect(Authn::webhooks())->toBeInstanceOf(SignatureVerifier::class)
+        ->and(Authn::webhooks())->toBe(app(SignatureVerifier::class));
+});
+
+it('exposes resource manager passthroughs', function (): void {
+    expect(Authn::users())->toBeInstanceOf(UsersManager::class);
+    expect(Authn::sessions())->toBeInstanceOf(SessionsManager::class);
+    expect(Authn::invitations())->toBeInstanceOf(InvitationsManager::class);
+    expect(Authn::instance())->toBeInstanceOf(InstanceManager::class);
+});
+
+it('returns null from auth() when no middleware has populated the request attributes', function (): void {
+    expect(Authn::auth())->toBeNull();
+});

--- a/tests/JwksCacheBindingTest.php
+++ b/tests/JwksCacheBindingTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Tokens\TokenVerifier;
+use Illuminate\Support\Facades\Cache;
+use Psr\SimpleCache\CacheInterface;
+
+function cachePropertyOf(TokenVerifier $verifier): CacheInterface
+{
+    $reflection = new ReflectionClass($verifier);
+    $prop = $reflection->getProperty('cache');
+    $prop->setAccessible(true);
+
+    /** @var CacheInterface $cache */
+    $cache = $prop->getValue($verifier);
+
+    return $cache;
+}
+
+it('wires the default cache store into TokenVerifier as PSR-16', function (): void {
+    /** @var TokenVerifier $verifier */
+    $verifier = app(TokenVerifier::class);
+
+    $cache = cachePropertyOf($verifier);
+
+    expect($cache)->toBeInstanceOf(CacheInterface::class);
+    expect($cache)->toBe(Cache::store());
+});
+
+it('honours jwks_cache_store when a specific store is configured', function (): void {
+    config()->set('cache.stores.jwks_test_store', ['driver' => 'array', 'serialize' => false]);
+    config()->set('authn.jwks_cache_store', 'jwks_test_store');
+
+    /** @var TokenVerifier $verifier */
+    $verifier = app(TokenVerifier::class);
+
+    expect(cachePropertyOf($verifier))->toBe(Cache::store('jwks_test_store'));
+});

--- a/tests/MissingKeyTest.php
+++ b/tests/MissingKeyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+
+it('explains how to fix a missing AUTHN_SECRET_KEY', function (): void {
+    config()->set('authn.secret_key', null);
+
+    expect(fn () => app(Client::class))
+        ->toThrow(RuntimeException::class, 'AUTHN_SECRET_KEY');
+});
+
+it('explains how to fix a missing AUTHN_PUBLISHABLE_KEY', function (): void {
+    config()->set('authn.publishable_key', null);
+
+    expect(fn () => app(TokenVerifier::class))
+        ->toThrow(RuntimeException::class, 'AUTHN_PUBLISHABLE_KEY');
+});
+
+it('explains how to fix a missing AUTHN_WEBHOOK_SECRET', function (): void {
+    config()->set('authn.webhook_signing_secret', null);
+    config()->set('authn.webhook_signing_secrets', []);
+
+    expect(fn () => app(SignatureVerifier::class))
+        ->toThrow(RuntimeException::class, 'AUTHN_WEBHOOK_SECRET');
+});
+
+it('treats whitespace-only keys as missing', function (): void {
+    config()->set('authn.secret_key', '   ');
+
+    expect(fn () => app(Client::class))
+        ->toThrow(RuntimeException::class, 'AUTHN_SECRET_KEY');
+});
+
+it('accepts a rotation list when the primary secret is unset', function (): void {
+    config()->set('authn.webhook_signing_secret', null);
+    config()->set('authn.webhook_signing_secrets', ['whsec_old', 'whsec_older']);
+
+    expect(app(SignatureVerifier::class))->toBeInstanceOf(SignatureVerifier::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,11 +5,22 @@ declare(strict_types=1);
 namespace Authn\Sdk\Laravel\Tests;
 
 use Authn\Sdk\Laravel\AuthnServiceProvider;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
+    /**
+     * Default publishable key — base64url-encoded "test.authn.sh$" so it
+     * decodes through `Authn\Sdk\Util\PublishableKey::frontendApiUrl()`.
+     */
+    public const TEST_PUBLISHABLE_KEY = 'pk_test_dGVzdC5hdXRobi5zaCQ';
+
+    public const TEST_SECRET_KEY = 'sk_test_default';
+
+    public const TEST_WEBHOOK_SECRET = 'whsec_dGVzdC1zZWNyZXQ';
+
     /**
      * @param  Application  $app
      * @return list<class-string>
@@ -17,5 +28,18 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [AuthnServiceProvider::class];
+    }
+
+    /**
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        /** @var Repository $config */
+        $config = $app['config'];
+
+        $config->set('authn.secret_key', self::TEST_SECRET_KEY);
+        $config->set('authn.publishable_key', self::TEST_PUBLISHABLE_KEY);
+        $config->set('authn.webhook_signing_secret', self::TEST_WEBHOOK_SECRET);
     }
 }


### PR DESCRIPTION
## Summary

Implements [SPL-2](https://github.com/authn-sh/sdk-php-laravel/issues/2) — fills in the empty SPL-1 service provider so a fresh Laravel 11/12 app can resolve `authn-sh/sdk-php` directly from the container or the `Authn` facade after just setting `AUTHN_SECRET_KEY` / `AUTHN_PUBLISHABLE_KEY` / `AUTHN_WEBHOOK_SECRET`. Middleware + Blade directives still land in SPL-3.

### `config/authn.php`

Env-driven keys with sensible defaults: publishable / secret keys, optional API URL overrides, webhook signing secret + rotation list + tolerance, JWKS cache TTL + store + allowed clock skew.

### `AuthnServiceProvider`

**`register()`**
- `mergeConfigFrom()` so customers don't need to publish to get defaults.
- Singletons for `Authn\Sdk\Client`, `TokenVerifier`, `SignatureVerifier` built from config; helpful `RuntimeException` mentioning the env var name when a required key is missing or whitespace-only.
- `TokenVerifier` wired to Laravel's cache repository (default store, or a named store via `authn.jwks_cache_store`) — the Laravel repo implements PSR-16 directly.
- `AuthnManager` singleton bound under `authn.manager` (the facade accessor) and `AuthnManager::class`.
- String aliases `authn.client` / `authn.tokens` / `authn.webhooks` for Tinker convenience.

**`boot()`**
- Publishes `config/authn.php` under tag `authn-config` (console only).

### `Authn\Sdk\Laravel\AuthnManager`

Lazy facade backend with `client()`, `tokens()`, `webhooks()`, `auth()` (returns `null` until SPL-3 middleware populates the request attribute), and one passthrough per BAPI resource manager.

### `Authn` facade

`@method static` annotations for every `AuthnManager` method so PHPStan/Larastan tracks the static-proxy surface.

## Tests

19 Pest tests (Orchestra Testbench), all green:

- `BindingsTest` — singleton identity for `Client` / `TokenVerifier` / `SignatureVerifier` / `AuthnManager` + string-alias resolution + `api_url` override.
- `FacadeTest` — `Authn::client/tokens/webhooks` routing, resource passthroughs, `auth()` null without middleware.
- `ConfigPublishTest` — `vendor:publish --tag=authn-config` writes the file.
- `MissingKeyTest` — missing/whitespace secret key, publishable key, and webhook secret each produce the documented `RuntimeException`; rotation list alone satisfies the webhook requirement.
- `JwksCacheBindingTest` — `TokenVerifier` wired to the default cache store by default, and to `authn.jwks_cache_store` when configured.

**Final: 19 pass, 42 assertions.** PHPStan + Larastan @ level 10 clean. Pint clean.

## Test plan

- [x] `composer test` — 19/19
- [x] `composer phpstan` — clean
- [x] `composer pint` — clean
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 / 8.5 × Laravel 11 / 12 (8 cells)

Closes #2