### PR TITLE
Add AuthenticateWithAuthn middleware + Blade directives + user-resolver hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
         "mockery/mockery": "^1.6",
+        "nyholm/psr7": "^1.8",
         "orchestra/testbench": "^9.0 || ^10.0",
         "pestphp/pest": "^3.0",
         "phpstan/phpstan": "^2.1"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - vendor/larastan/larastan/extension.neon
+    - vendor/pestphp/pest/extension.neon
 
 parameters:
     level: 10

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -16,15 +16,23 @@ use Authn\Sdk\Resources\WebhookEndpointsManager;
 use Authn\Sdk\Tokens\TokenVerifier;
 use Authn\Sdk\Tokens\VerifiedClaims;
 use Authn\Sdk\Webhooks\SignatureVerifier;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 
 /**
  * Single entry point used by the `Authn` facade. Lazily resolves the underlying
  * SDK objects from the container so they're not all built unless you call them.
+ *
+ * Also stores the optional `User` resolver: a closure that maps a verified set
+ * of claims onto an `Authenticatable` so `Auth::user()` returns the customer's
+ * own model after AuthenticateWithAuthn runs.
  */
 class AuthnManager
 {
+    /** @var (callable(VerifiedClaims): ?Authenticatable)|null */
+    private $userResolver = null;
+
     public function __construct(private readonly Container $container) {}
 
     public function client(): Client
@@ -70,6 +78,27 @@ class AuthnManager
         $claims = $request->attributes->get('authn.claims');
 
         return $claims instanceof VerifiedClaims ? $claims : null;
+    }
+
+    /**
+     * Register a callable that maps verified claims to an `Authenticatable`.
+     *
+     * The resolver runs inside the AuthenticateWithAuthn middleware. Pass `null`
+     * to clear a previously-registered resolver.
+     *
+     * @param  (callable(VerifiedClaims): ?Authenticatable)|null  $resolver
+     */
+    public function resolveUserUsing(?callable $resolver): void
+    {
+        $this->userResolver = $resolver;
+    }
+
+    /**
+     * @return (callable(VerifiedClaims): ?Authenticatable)|null
+     */
+    public function getUserResolver(): ?callable
+    {
+        return $this->userResolver;
     }
 
     public function users(): UsersManager

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
 use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Tokens\VerifiedClaims;
 use Authn\Sdk\Webhooks\SignatureVerifier;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
@@ -39,6 +44,42 @@ class AuthnServiceProvider extends ServiceProvider
                 $this->configPath() => $this->app->configPath('authn.php'),
             ], 'authn-config');
         }
+
+        $this->registerMiddleware();
+        $this->registerBladeDirectives();
+    }
+
+    private function registerMiddleware(): void
+    {
+        /** @var Router $router */
+        $router = $this->app->make('router');
+        $router->aliasMiddleware('authn', AuthenticateWithAuthn::class);
+    }
+
+    private function registerBladeDirectives(): void
+    {
+        Blade::if('authnSignedIn', fn (): bool => self::currentClaims() !== null);
+        Blade::if('authnSignedOut', fn (): bool => self::currentClaims() === null);
+
+        // v0.1 stub: organization roles + permissions land in v0.2.
+        Blade::if('authnHas', fn (string $check): bool => false);
+    }
+
+    private static function currentClaims(): ?VerifiedClaims
+    {
+        $app = \Illuminate\Container\Container::getInstance();
+        if (! $app->bound('request')) {
+            return null;
+        }
+
+        $request = $app->make('request');
+        if (! $request instanceof Request) {
+            return null;
+        }
+
+        $claims = $request->attributes->get(AuthenticateWithAuthn::REQUEST_ATTRIBUTE);
+
+        return $claims instanceof VerifiedClaims ? $claims : null;
     }
 
     private function configPath(): string

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Authn\Sdk\Resources\RedirectUrlsManager redirectUrls()
  * @method static \Authn\Sdk\Resources\InstanceManager instance()
  * @method static \Authn\Sdk\Resources\WebhookEndpointsManager webhookEndpoints()
+ * @method static void resolveUserUsing(?callable $resolver)
  *
  * @see AuthnManager
  */

--- a/src/Http/Middleware/AuthenticateWithAuthn.php
+++ b/src/Http/Middleware/AuthenticateWithAuthn.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Http\Middleware;
+
+use Authn\Sdk\Laravel\AuthnManager;
+use Authn\Sdk\Tokens\TokenInvalidException;
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Closure;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateWithAuthn
+{
+    public const COOKIE_NAME = '__session';
+
+    public const REQUEST_ATTRIBUTE = 'authn.claims';
+
+    public function __construct(
+        private readonly TokenVerifier $verifier,
+        private readonly AuthnManager $manager,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $jwt = $this->extractJwt($request);
+
+        if ($jwt === null) {
+            return $this->unauthorized('No authn.sh session token on the request.');
+        }
+
+        try {
+            $claims = $this->verifier->verify($jwt);
+        } catch (TokenInvalidException $e) {
+            return $this->unauthorized($e->getMessage());
+        }
+
+        $request->attributes->set(self::REQUEST_ATTRIBUTE, $claims);
+
+        $this->bindResolvedUser($claims);
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        return $response;
+    }
+
+    private function extractJwt(Request $request): ?string
+    {
+        $authorization = $request->headers->get('authorization');
+        if (is_string($authorization) && str_starts_with($authorization, 'Bearer ')) {
+            $token = trim(substr($authorization, 7));
+            if ($token !== '') {
+                return $token;
+            }
+        }
+
+        $cookie = $request->cookies->get(self::COOKIE_NAME);
+
+        return is_string($cookie) && $cookie !== '' ? $cookie : null;
+    }
+
+    private function bindResolvedUser(VerifiedClaims $claims): void
+    {
+        $resolver = $this->manager->getUserResolver();
+        if ($resolver === null) {
+            return;
+        }
+
+        $user = $resolver($claims);
+        if ($user instanceof Authenticatable) {
+            Auth::guard()->setUser($user);
+        }
+    }
+
+    private function unauthorized(string $message): JsonResponse
+    {
+        return new JsonResponse([
+            'errors' => [[
+                'code' => 'authn_unauthorized',
+                'message' => $message,
+            ]],
+        ], 401);
+    }
+}

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+
+final class BladeDirectivesTest extends TestCase
+{
+    private const AUTHENTICATED_TEMPLATE = <<<'BLADE'
+@authnSignedIn
+SIGNED_IN
+@endauthnSignedIn
+@authnSignedOut
+SIGNED_OUT
+@endauthnSignedOut
+@authnHas('role:org:admin')
+HAS_ROLE
+@else
+NO_ROLE
+@endauthnHas
+BLADE;
+
+    private const ANONYMOUS_TEMPLATE = <<<'BLADE'
+@authnSignedIn
+SIGNED_IN
+@endauthnSignedIn
+@authnSignedOut
+SIGNED_OUT
+@endauthnSignedOut
+BLADE;
+
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render',
+            fn () => Blade::render(self::AUTHENTICATED_TEMPLATE),
+        );
+
+        Route::get('/render-anonymous', fn () => Blade::render(self::ANONYMOUS_TEMPLATE));
+    }
+
+    public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render')->getContent();
+
+        $this->assertStringContainsString('SIGNED_IN', (string) $body);
+        $this->assertStringNotContainsString('SIGNED_OUT', (string) $body);
+    }
+
+    public function test_authn_has_always_renders_the_else_branch_in_v01(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render')->getContent();
+
+        $this->assertStringContainsString('NO_ROLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ROLE', (string) $body);
+    }
+
+    public function test_renders_the_signed_out_branch_on_an_anonymous_request(): void
+    {
+        $body = $this->get('/render-anonymous')->getContent();
+
+        $this->assertStringContainsString('SIGNED_OUT', (string) $body);
+        $this->assertStringNotContainsString('SIGNED_IN', (string) $body);
+    }
+}

--- a/tests/Http/MiddlewareTest.php
+++ b/tests/Http/MiddlewareTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Http;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\Support\JwtFixture;
+use Authn\Sdk\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+final class MiddlewareTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/me', function () {
+            return response()->json([
+                'sub' => Authn::auth()?->sub,
+                'sid' => Authn::auth()?->sid,
+                'attribute_present' => request()->attributes->has(AuthenticateWithAuthn::REQUEST_ATTRIBUTE),
+            ]);
+        });
+    }
+
+    public function test_returns_200_with_claims_when_a_valid_jwt_is_in_the_authorization_header(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/me');
+
+        $response->assertOk();
+        $response->assertJson([
+            'sub' => 'user_2x',
+            'sid' => 'sess_1y',
+            'attribute_present' => true,
+        ]);
+    }
+
+    public function test_returns_401_with_bapi_envelope_when_no_jwt_is_present(): void
+    {
+        $response = $this->get('/me');
+
+        $response->assertStatus(401);
+        $response->assertJson(['errors' => [['code' => 'authn_unauthorized']]]);
+    }
+
+    public function test_returns_401_when_the_jwt_signature_is_invalid(): void
+    {
+        $forged = (new JwtFixture)->sign($this->env->claims());
+
+        $response = $this->withHeader('Authorization', "Bearer {$forged}")->get('/me');
+
+        $response->assertStatus(401);
+        $response->assertJson(['errors' => [['code' => 'authn_unauthorized']]]);
+    }
+
+    public function test_returns_401_when_the_jwt_has_expired(): void
+    {
+        $now = time();
+        $jwt = $this->env->signJwt(['iat' => $now - 7200, 'exp' => $now - 60]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/me');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_reads_the_jwt_from_the_session_cookie_when_no_header_is_set(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withUnencryptedCookie(AuthenticateWithAuthn::COOKIE_NAME, $jwt)->get('/me');
+
+        $response->assertOk();
+        $response->assertJson(['sub' => 'user_2x']);
+    }
+
+    public function test_exposes_verified_claims_through_the_authn_facade_during_the_request(): void
+    {
+        $jwt = $this->env->signJwt(['sub' => 'user_xyz']);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/me');
+
+        $response->assertJson(['sub' => 'user_xyz']);
+    }
+
+    public function test_returns_null_from_authn_auth_outside_of_a_request(): void
+    {
+        $this->assertNull(Authn::auth());
+    }
+}

--- a/tests/Support/AuthnTestEnvironment.php
+++ b/tests/Support/AuthnTestEnvironment.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Support;
+
+use Authn\Sdk\Tokens\TokenVerifier;
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * Spins up a TokenVerifier wired against a freshly-generated RSA keypair and
+ * a stub PSR-18 client serving the matching JWKS. Tests that need to forge
+ * JWTs against the bound verifier use this to swap the singleton.
+ */
+final class AuthnTestEnvironment
+{
+    public readonly JwtFixture $fixture;
+
+    public readonly StaticBodyClient $http;
+
+    public readonly MemoryCache $cache;
+
+    public function __construct(public readonly string $frontendApiUrl = 'https://test.authn.sh')
+    {
+        $this->fixture = new JwtFixture;
+        $this->http = new StaticBodyClient($this->fixture->jwksJson());
+        $this->cache = new MemoryCache;
+    }
+
+    public function bind(?Application $app): void
+    {
+        if ($app === null) {
+            throw new \RuntimeException('Cannot bind TokenVerifier without an application instance.');
+        }
+
+        $app->singleton(TokenVerifier::class, fn (): TokenVerifier => new TokenVerifier(
+            publishableKey: 'pk_test_dummy',
+            frontendApiUrl: $this->frontendApiUrl,
+            cache: $this->cache,
+            http: $this->http,
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public function claims(array $overrides = []): array
+    {
+        $now = time();
+
+        return array_merge([
+            'iss' => $this->frontendApiUrl,
+            'sub' => 'user_2x',
+            'sid' => 'sess_1y',
+            'azp' => 'https://app.example',
+            'iat' => $now - 1,
+            'exp' => $now + 3600,
+            'nbf' => $now - 5,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $claimsOverride
+     */
+    public function signJwt(?array $claimsOverride = null): string
+    {
+        return $this->fixture->sign($this->claims($claimsOverride ?? []));
+    }
+}

--- a/tests/Support/JwtFixture.php
+++ b/tests/Support/JwtFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Support;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+
+/**
+ * Test helper: generates a fresh RSA keypair, can sign JWTs against it, and
+ * exposes the matching JWKS document for the verifier to consume.
+ */
+final class JwtFixture
+{
+    public readonly JWK $jwk;
+
+    public readonly string $kid;
+
+    public function __construct(string $kid = 'test-kid-1')
+    {
+        $this->kid = $kid;
+        $this->jwk = JWKFactory::createRSAKey(2048, [
+            'alg' => 'RS256',
+            'use' => 'sig',
+            'kid' => $kid,
+        ]);
+    }
+
+    public function jwksJson(): string
+    {
+        $jwks = new JWKSet([$this->jwk->toPublic()]);
+
+        return json_encode($jwks, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     * @param  array<string, mixed>  $headerOverrides
+     */
+    public function sign(array $claims, array $headerOverrides = []): string
+    {
+        $builder = new JWSBuilder(new AlgorithmManager([new RS256]));
+        $header = array_merge(
+            ['alg' => 'RS256', 'typ' => 'JWT', 'kid' => $this->kid],
+            $headerOverrides,
+        );
+
+        $jws = $builder
+            ->create()
+            ->withPayload(json_encode($claims, JSON_THROW_ON_ERROR))
+            ->addSignature($this->jwk, $header)
+            ->build();
+
+        return (new CompactSerializer)->serialize($jws);
+    }
+}

--- a/tests/Support/MemoryCache.php
+++ b/tests/Support/MemoryCache.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Support;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+final class MemoryCache implements CacheInterface
+{
+    /** @var array<string, array{value: mixed, expiresAt: int|null}> */
+    private array $store = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (! $this->has($key)) {
+            return $default;
+        }
+
+        return $this->store[$key]['value'];
+    }
+
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    {
+        $expiresAt = null;
+        if (is_int($ttl)) {
+            $expiresAt = time() + $ttl;
+        } elseif ($ttl instanceof DateInterval) {
+            $expiresAt = (new \DateTimeImmutable)->add($ttl)->getTimestamp();
+        }
+
+        $this->store[$key] = ['value' => $value, 'expiresAt' => $expiresAt];
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->store[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $out = [];
+        foreach ($keys as $key) {
+            $out[$key] = $this->get($key, $default);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  iterable<string, mixed>  $values
+     */
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        if (! isset($this->store[$key])) {
+            return false;
+        }
+
+        $expiresAt = $this->store[$key]['expiresAt'];
+        if ($expiresAt !== null && $expiresAt < time()) {
+            unset($this->store[$key]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Support/StaticBodyClient.php
+++ b/tests/Support/StaticBodyClient.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Support;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Tiny PSR-18 client that returns a queued body for a queued status, counting calls.
+ *
+ * Built specifically for JWKS-fetch tests where we need to count how many times
+ * the SDK hit the JWKS endpoint and swap the response between calls.
+ */
+final class StaticBodyClient implements ClientInterface
+{
+    public int $calls = 0;
+
+    /** @var list<string|null> */
+    public array $bodies;
+
+    public function __construct(?string ...$bodies)
+    {
+        $this->bodies = $bodies === [] ? [null] : array_values($bodies);
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $idx = min($this->calls, count($this->bodies) - 1);
+        $body = $this->bodies[$idx];
+        $this->calls++;
+
+        $factory = new Psr17Factory;
+        $response = $factory->createResponse($body === null ? 500 : 200)
+            ->withHeader('Content-Type', 'application/json');
+        if ($body !== null) {
+            $response = $response->withBody($factory->createStream($body));
+        }
+
+        return $response;
+    }
+}

--- a/tests/Support/TestUser.php
+++ b/tests/Support/TestUser.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Support;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Minimal Authenticatable used by middleware tests to verify the User-resolver
+ * hook calls Auth::guard()->setUser(...).
+ */
+final class TestUser implements Authenticatable
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $email = '',
+    ) {}
+
+    public function getAuthIdentifierName(): string
+    {
+        return 'id';
+    }
+
+    public function getAuthIdentifier(): string
+    {
+        return $this->id;
+    }
+
+    public function getAuthPasswordName(): string
+    {
+        return 'password';
+    }
+
+    public function getAuthPassword(): string
+    {
+        return '';
+    }
+
+    public function getRememberToken(): ?string
+    {
+        return null;
+    }
+
+    public function setRememberToken($value): void {}
+
+    public function getRememberTokenName(): string
+    {
+        return 'remember_token';
+    }
+}

--- a/tests/UserResolverTest.php
+++ b/tests/UserResolverTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\Support\TestUser;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+
+final class UserResolverTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/whoami', fn () => response()->json([
+            'auth_user_id' => Auth::user()?->getAuthIdentifier(),
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        // Resolver lives on the singleton manager; clear it between tests.
+        Authn::resolveUserUsing(null);
+
+        parent::tearDown();
+    }
+
+    public function test_routes_claims_through_the_resolver_and_binds_auth_user(): void
+    {
+        Authn::resolveUserUsing(fn (VerifiedClaims $claims) => new TestUser($claims->sub));
+
+        $jwt = $this->env->signJwt(['sub' => 'user_42']);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/whoami')
+            ->assertOk()
+            ->assertJson(['auth_user_id' => 'user_42']);
+    }
+
+    public function test_leaves_auth_user_null_when_no_resolver_is_registered(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/whoami')
+            ->assertOk()
+            ->assertJson(['auth_user_id' => null]);
+    }
+
+    public function test_leaves_auth_user_null_when_the_resolver_returns_null(): void
+    {
+        Authn::resolveUserUsing(static fn (VerifiedClaims $claims): ?TestUser => null);
+
+        $jwt = $this->env->signJwt();
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/whoami')
+            ->assertOk()
+            ->assertJson(['auth_user_id' => null]);
+    }
+}


### PR DESCRIPTION
## Summary

Implements [SPL-3](https://github.com/authn-sh/sdk-php-laravel/issues/3) — the runtime side of the Laravel package. After this lands, a Laravel app needs three lines to require auth on a route:

\`\`\`php
Route::middleware('authn')->group(function () {
    Route::get('/me', fn () => Authn::auth());
});
\`\`\`

### Middleware — \`Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn\`

- Aliased as \`authn\` via \`Router::aliasMiddleware\` in \`AuthnServiceProvider::boot()\`.
- JWT source order: \`Authorization: Bearer\` header, then \`__session\` cookie. (Customers using the cookie path must add \`__session\` to \`EncryptCookies::\$except\`.)
- On success: sets \`request->attributes->\`\`authn.claims\`\`\`, invokes the registered user resolver if any, and calls \`Auth::guard()->setUser(\$user)\` when the resolver returns an \`Authenticatable\`.
- On failure: 401 with the BAPI error envelope shape \`{ errors: [{ code: 'authn_unauthorized', message: '...' }] }\`.

### User resolver hook

- \`AuthnManager::resolveUserUsing(?callable \$resolver)\` stores the callable on the singleton; pass \`null\` to clear.
- The \`Authn\` facade gets a matching \`@method static\` annotation.

### Blade directives

- \`@authnSignedIn\` / \`@authnSignedOut\` — read the request attribute.
- \`@authnHas('role:foo' | 'permission:bar')\` — v0.1 stub: always returns false (functional once orgs ship in v0.2).

### Tests (Pest + Orchestra Testbench, 13 new — 32 total)

- **MiddlewareTest** — 200 for valid header, 401 for missing/forged/expired JWTs, cookie path, claims exposed via \`Authn::auth()\`, null outside the request lifecycle.
- **UserResolverTest** — resolver binds \`Auth::user()\`; no resolver leaves it null; resolver returning null leaves it null.
- **BladeDirectivesTest** — signed-in / signed-out / \`@authnHas\` always-else.
- Helpers: \`AuthnTestEnvironment\` + \`TestUser\`. \`JwtFixture\` / \`MemoryCache\` / \`StaticBodyClient\` vendored from \`authn-sh/sdk-php\`'s autoload-dev.

The three Laravel-heavy test files use class-style PHPUnit syntax (Pest still runs them) so PHPStan understands \`\$this\` natively; the existing functional Pest tests stay as-is.

### Tooling

- Adds \`nyholm/psr7\` to require-dev (used by \`StaticBodyClient\`).
- \`phpstan.neon\` now includes \`vendor/pestphp/pest/extension.neon\` for Pest-aware analysis.

**Final: 32 pass, 65 assertions.** PHPStan + Larastan @ level 10 clean. Pint clean.

## Test plan

- [x] \`composer test\` — 32/32
- [x] \`composer phpstan\` — clean
- [x] \`composer pint\` — clean
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 / 8.5 × Laravel 11 / 12 (8 cells)

Closes #3