### PR TITLE
feat(spl-1): @authnHas Blade directive functional implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Laravel package for [authn.sh](https://authn.sh) — auto-discovered service provider, container bindings, middleware, Blade directives, and an `Authn` facade. Wraps [`authn-sh/sdk-php`](https://github.com/authn-sh/sdk-php) for Laravel 11+.
 
-> Status: **0.1.x pre-release.** Bindings, middleware, and Blade directives land in SPL-2 / SPL-3. This release is a bootstrap-only skeleton.
-
 ## Requirements
 
 - PHP **8.2+**
@@ -16,13 +14,63 @@ Laravel package for [authn.sh](https://authn.sh) — auto-discovered service pro
 composer require authn-sh/sdk-php-laravel
 ```
 
-The service provider auto-discovers. Once SPL-2 lands you'll be able to publish the config:
+The service provider auto-discovers. Publish the config:
 
 ```bash
 php artisan vendor:publish --tag=authn-config
 ```
 
-…and resolve the SDK from the container or via the `Authn` facade.
+## Middleware
+
+Register `authn` on routes that require a valid session JWT:
+
+```php
+Route::middleware('authn')->group(function () {
+    Route::get('/dashboard', DashboardController::class);
+});
+```
+
+## Blade directives
+
+### `@authnSignedIn` / `@authnSignedOut`
+
+```blade
+@authnSignedIn
+    <p>Welcome back, {{ Authn::auth()->sub }}</p>
+@endauthnSignedIn
+
+@authnSignedOut
+    <a href="/login">Sign in</a>
+@endauthnSignedOut
+```
+
+### `@authnHas`
+
+Evaluates organization roles and permissions from the active session JWT:
+
+```blade
+@authnHas('role:org:admin')
+    <a href="/admin">Admin panel</a>
+@else
+    <p>You do not have admin access.</p>
+@endauthnHas
+
+@authnHas('permission:org:billing:manage')
+    <a href="/billing">Billing</a>
+@endauthnHas
+```
+
+The argument must be prefixed with `role:` or `permission:`. Any other prefix raises an `InvalidArgumentException` at render time so typos fail loudly.
+
+## Facade methods
+
+```php
+use Authn\Sdk\Laravel\Facades\Authn;
+
+$claims = Authn::auth();          // ?VerifiedClaims — null outside an authn-authenticated request
+Authn::hasRole('org:admin');      // bool
+Authn::hasPermission('org:foo:bar'); // bool
+```
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.1@dev || ^0.2@dev",
+        "authn-sh/sdk-php": "dev-main || ^0.2",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -72,11 +72,8 @@
     "prefer-stable": true,
     "repositories": {
         "sdk-php": {
-            "type": "path",
-            "url": "../sdk-php",
-            "options": {
-                "symlink": false
-            }
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.1",
+        "authn-sh/sdk-php": "^0.1@dev || ^0.2@dev",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -65,9 +65,18 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.1.x-dev"
+            "dev-main": "0.2.x-dev"
         }
     },
-    "minimum-stability": "stable",
-    "prefer-stable": true
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": {
+        "sdk-php": {
+            "type": "path",
+            "url": "../sdk-php",
+            "options": {
+                "symlink": false
+            }
+        }
+    }
 }

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -101,6 +101,16 @@ class AuthnManager
         return $this->userResolver;
     }
 
+    public function hasRole(string $key): bool
+    {
+        return $this->auth()?->hasRole($key) ?? false;
+    }
+
+    public function hasPermission(string $key): bool
+    {
+        return $this->auth()?->hasPermission($key) ?? false;
+    }
+
     public function users(): UsersManager
     {
         return $this->client()->users();

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
 
@@ -61,8 +62,19 @@ class AuthnServiceProvider extends ServiceProvider
         Blade::if('authnSignedIn', fn (): bool => self::currentClaims() !== null);
         Blade::if('authnSignedOut', fn (): bool => self::currentClaims() === null);
 
-        // v0.1 stub: organization roles + permissions land in v0.2.
-        Blade::if('authnHas', fn (string $check): bool => false);
+        Blade::if('authnHas', function (string $check): bool {
+            if (str_starts_with($check, 'role:')) {
+                return self::currentClaims()?->hasRole(substr($check, 5)) ?? false;
+            }
+
+            if (str_starts_with($check, 'permission:')) {
+                return self::currentClaims()?->hasPermission(substr($check, 11)) ?? false;
+            }
+
+            throw new InvalidArgumentException(
+                "authnHas: unrecognised check \"{$check}\" — prefix with \"role:\" or \"permission:\".",
+            );
+        });
     }
 
     private static function currentClaims(): ?VerifiedClaims

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -25,6 +25,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Authn\Sdk\Resources\RedirectUrlsManager redirectUrls()
  * @method static \Authn\Sdk\Resources\InstanceManager instance()
  * @method static \Authn\Sdk\Resources\WebhookEndpointsManager webhookEndpoints()
+ * @method static bool hasRole(string $key)
+ * @method static bool hasPermission(string $key)
  * @method static void resolveUserUsing(?callable $resolver)
  *
  * @see AuthnManager

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -8,16 +8,20 @@ use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
 use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\ViewException;
 
 final class BladeDirectivesTest extends TestCase
 {
-    private const AUTHENTICATED_TEMPLATE = <<<'BLADE'
+    private const SIGNED_IN_OUT_TEMPLATE = <<<'BLADE'
 @authnSignedIn
 SIGNED_IN
 @endauthnSignedIn
 @authnSignedOut
 SIGNED_OUT
 @endauthnSignedOut
+BLADE;
+
+    private const ROLE_TEMPLATE = <<<'BLADE'
 @authnHas('role:org:admin')
 HAS_ROLE
 @else
@@ -25,13 +29,12 @@ NO_ROLE
 @endauthnHas
 BLADE;
 
-    private const ANONYMOUS_TEMPLATE = <<<'BLADE'
-@authnSignedIn
-SIGNED_IN
-@endauthnSignedIn
-@authnSignedOut
-SIGNED_OUT
-@endauthnSignedOut
+    private const PERMISSION_TEMPLATE = <<<'BLADE'
+@authnHas('permission:org:foo:bar')
+HAS_PERMISSION
+@else
+NO_PERMISSION
+@endauthnHas
 BLADE;
 
     private AuthnTestEnvironment $env;
@@ -44,31 +47,31 @@ BLADE;
         $this->env->bind($this->app);
 
         Route::middleware(AuthenticateWithAuthn::class)->get(
-            '/render',
-            fn () => Blade::render(self::AUTHENTICATED_TEMPLATE),
+            '/render-signed-in-out',
+            fn () => Blade::render(self::SIGNED_IN_OUT_TEMPLATE),
         );
 
-        Route::get('/render-anonymous', fn () => Blade::render(self::ANONYMOUS_TEMPLATE));
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-role',
+            fn () => Blade::render(self::ROLE_TEMPLATE),
+        );
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-permission',
+            fn () => Blade::render(self::PERMISSION_TEMPLATE),
+        );
+
+        Route::get('/render-anonymous', fn () => Blade::render(self::SIGNED_IN_OUT_TEMPLATE));
     }
 
     public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
     {
         $jwt = $this->env->signJwt();
 
-        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render')->getContent();
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-signed-in-out')->getContent();
 
         $this->assertStringContainsString('SIGNED_IN', (string) $body);
         $this->assertStringNotContainsString('SIGNED_OUT', (string) $body);
-    }
-
-    public function test_authn_has_always_renders_the_else_branch_in_v01(): void
-    {
-        $jwt = $this->env->signJwt();
-
-        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render')->getContent();
-
-        $this->assertStringContainsString('NO_ROLE', (string) $body);
-        $this->assertStringNotContainsString('HAS_ROLE', (string) $body);
     }
 
     public function test_renders_the_signed_out_branch_on_an_anonymous_request(): void
@@ -77,5 +80,71 @@ BLADE;
 
         $this->assertStringContainsString('SIGNED_OUT', (string) $body);
         $this->assertStringNotContainsString('SIGNED_IN', (string) $body);
+    }
+
+    public function test_authn_has_role_renders_truthy_branch_when_jwt_carries_matching_role(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'rol' => 'org:admin']]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-role')->getContent();
+
+        $this->assertStringContainsString('HAS_ROLE', (string) $body);
+        $this->assertStringNotContainsString('NO_ROLE', (string) $body);
+    }
+
+    public function test_authn_has_role_renders_else_branch_when_role_does_not_match(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'rol' => 'org:member']]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-role')->getContent();
+
+        $this->assertStringContainsString('NO_ROLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ROLE', (string) $body);
+    }
+
+    public function test_authn_has_role_renders_else_branch_when_jwt_carries_no_org_claim(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-role')->getContent();
+
+        $this->assertStringContainsString('NO_ROLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ROLE', (string) $body);
+    }
+
+    public function test_authn_has_permission_renders_truthy_branch_when_jwt_carries_matching_permission(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'per' => ['org:foo:bar']]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-permission')->getContent();
+
+        $this->assertStringContainsString('HAS_PERMISSION', (string) $body);
+        $this->assertStringNotContainsString('NO_PERMISSION', (string) $body);
+    }
+
+    public function test_authn_has_permission_renders_else_branch_when_permission_does_not_match(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'per' => ['org:other']]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-permission')->getContent();
+
+        $this->assertStringContainsString('NO_PERMISSION', (string) $body);
+        $this->assertStringNotContainsString('HAS_PERMISSION', (string) $body);
+    }
+
+    public function test_authn_has_throws_for_unrecognised_prefix(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-garbage',
+            fn () => Blade::render("@authnHas('garbage')\nFOO\n@endauthnHas"),
+        );
+
+        $this->withoutExceptionHandling();
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessageMatches('/unrecognised check/');
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-garbage');
     }
 }

--- a/tests/HasRolePermissionTest.php
+++ b/tests/HasRolePermissionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Illuminate\Support\Facades\Route;
+
+final class HasRolePermissionTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-role', function () {
+            return response()->json(['result' => Authn::hasRole('org:admin')]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-permission', function () {
+            return response()->json(['result' => Authn::hasPermission('org:foo:bar')]);
+        });
+    }
+
+    public function test_has_role_returns_true_when_jwt_carries_matching_role(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'rol' => 'org:admin']]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-role')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_has_role_returns_false_when_role_does_not_match(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'rol' => 'org:member']]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-role')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_has_role_returns_false_when_no_org_claim(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-role')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_has_permission_returns_true_when_jwt_carries_matching_permission(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'per' => ['org:foo:bar']]]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-permission')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_has_permission_returns_false_when_permission_does_not_match(): void
+    {
+        $jwt = $this->env->signJwt(['org' => ['id' => 'org_1', 'per' => ['org:other']]]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-permission')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_has_role_and_permission_return_false_when_no_claims_bound(): void
+    {
+        expect(Authn::hasRole('org:admin'))->toBeFalse()
+            ->and(Authn::hasPermission('org:foo:bar'))->toBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the always-false v0.1 `@authnHas` stub with real evaluation using `VerifiedClaims->organization` from sdk-php SP-3
- `@authnHas('role:<key>')` delegates to `Organization::hasRole($key)`; `@authnHas('permission:<key>')` delegates to `Organization::hasPermission($key)`; any other prefix throws `InvalidArgumentException` at render time
- Adds `Authn::hasRole(string $key)` and `Authn::hasPermission(string $key)` facade proxy methods on `AuthnManager`
- Updates README Blade directives section with usage examples and drops the stub-false note
- 43 tests passing; PHPStan clean; Pint clean

## Dependency note

`authn-sh/sdk-php` constraint bumped to `^0.1@dev || ^0.2@dev` (`minimum-stability: dev`, `prefer-stable: true`) to pull in SP-3 from `dev-main`. Will be tightened back to `^0.2` once `sdk-php@v0.2.0` ships.

## Test plan

- [x] `@authnHas('role:org:admin')` renders truthy branch when JWT carries `org.rol = "org:admin"`
- [x] `@authnHas('role:org:admin')` renders else branch on role mismatch
- [x] `@authnHas('role:org:admin')` renders else branch when JWT has no `org` claim
- [x] `@authnHas('permission:org:foo:bar')` renders truthy / else branches correctly
- [x] `@authnHas('garbage')` raises `ViewException` wrapping `InvalidArgumentException`
- [x] `Authn::hasRole()` / `hasPermission()` return correct bool via HTTP cycle and return false with no request context
- [x] Existing `@authnSignedIn` / `@authnSignedOut` tests still pass