### PR TITLE
feat(mfa): RequiresMfa middleware + @authnRequiresMfa Blade directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.2",
+        "authn-sh/sdk-php": "^0.2 || dev-main",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -65,9 +65,9 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.2.x-dev"
+            "dev-main": "0.3.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.2 || dev-main",
+        "authn-sh/sdk-php": "dev-main || ^0.3",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -47,6 +47,12 @@
         "phpstan": "vendor/bin/phpstan analyse --no-progress",
         "pint": "vendor/bin/pint --test",
         "pint:fix": "vendor/bin/pint"
+    },
+    "repositories": {
+        "sdk-php": {
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
+        }
     },
     "config": {
         "sort-packages": true,

--- a/config/authn.php
+++ b/config/authn.php
@@ -73,4 +73,35 @@ return [
 
     'allowed_clock_skew' => (int) env('AUTHN_ALLOWED_CLOCK_SKEW', 5),
 
+    /*
+    |--------------------------------------------------------------------------
+    | URL helpers
+    |--------------------------------------------------------------------------
+    |
+    | Used by middleware to redirect unauthenticated or under-authenticated
+    | requests to the appropriate sign-in page.
+    |
+    */
+
+    'url' => [
+        'sign_in' => env('AUTHN_URL_SIGN_IN', '/sign-in'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | MFA enforcement
+    |--------------------------------------------------------------------------
+    |
+    | `max_age_seconds` is the maximum age of the second-factor proof accepted
+    | by the RequiresMfa middleware (default 30 minutes). `redirect_url` is
+    | where the middleware sends users who have not recently proved a second
+    | factor.
+    |
+    */
+
+    'mfa' => [
+        'max_age_seconds' => (int) env('AUTHN_MFA_MAX_AGE_SECONDS', 1800),
+        'redirect_url' => env('AUTHN_MFA_REDIRECT_URL', '/sign-in/factor-two'),
+    ],
+
 ];

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -6,6 +6,7 @@ namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
 use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
 use Authn\Sdk\Tokens\TokenVerifier;
 use Authn\Sdk\Tokens\VerifiedClaims;
 use Authn\Sdk\Webhooks\SignatureVerifier;
@@ -55,12 +56,15 @@ class AuthnServiceProvider extends ServiceProvider
         /** @var Router $router */
         $router = $this->app->make('router');
         $router->aliasMiddleware('authn', AuthenticateWithAuthn::class);
+        $router->aliasMiddleware('authn.requires_mfa', RequiresMfa::class);
     }
 
     private function registerBladeDirectives(): void
     {
         Blade::if('authnSignedIn', fn (): bool => self::currentClaims() !== null);
         Blade::if('authnSignedOut', fn (): bool => self::currentClaims() === null);
+
+        Blade::if('authnRequiresMfa', fn (): bool => self::currentClaims()?->twoFactorVerified === true);
 
         Blade::if('authnHas', function (string $check): bool {
             if (str_starts_with($check, 'role:')) {

--- a/src/Http/Middleware/RequiresMfa.php
+++ b/src/Http/Middleware/RequiresMfa.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Http\Middleware;
+
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresMfa
+{
+    public function handle(Request $request, Closure $next, ?string $maxAgeOverride = null): Response
+    {
+        $claims = $request->attributes->get(AuthenticateWithAuthn::REQUEST_ATTRIBUTE);
+
+        if (! $claims instanceof VerifiedClaims) {
+            $signInUrl = config('authn.url.sign_in');
+
+            return redirect(is_string($signInUrl) ? $signInUrl : '/sign-in');
+        }
+
+        if ($maxAgeOverride !== null) {
+            $maxAge = (int) $maxAgeOverride;
+        } else {
+            $configured = config('authn.mfa.max_age_seconds');
+            $maxAge = is_int($configured) ? $configured : 1800;
+        }
+
+        $age = $claims->secondFactorAgeSeconds;
+
+        if ($age === null || $age > $maxAge) {
+            $redirectUrl = config('authn.mfa.redirect_url');
+
+            return redirect(is_string($redirectUrl) ? $redirectUrl : '/sign-in/factor-two');
+        }
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        return $response;
+    }
+}

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -37,6 +37,14 @@ NO_PERMISSION
 @endauthnHas
 BLADE;
 
+    private const MFA_TEMPLATE = <<<'BLADE'
+@authnRequiresMfa
+MFA_VERIFIED
+@else
+MFA_NOT_VERIFIED
+@endauthnRequiresMfa
+BLADE;
+
     private AuthnTestEnvironment $env;
 
     protected function setUp(): void
@@ -62,6 +70,13 @@ BLADE;
         );
 
         Route::get('/render-anonymous', fn () => Blade::render(self::SIGNED_IN_OUT_TEMPLATE));
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-mfa',
+            fn () => Blade::render(self::MFA_TEMPLATE),
+        );
+
+        Route::get('/render-mfa-anonymous', fn () => Blade::render(self::MFA_TEMPLATE));
     }
 
     public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
@@ -146,5 +161,43 @@ BLADE;
         $this->expectExceptionMessageMatches('/unrecognised check/');
 
         $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-garbage');
+    }
+
+    public function test_authn_requires_mfa_renders_truthy_branch_when_second_factor_is_verified(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 120]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa')->getContent();
+
+        $this->assertStringContainsString('MFA_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_NOT_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_renders_else_branch_when_second_factor_is_not_verified(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, -1]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_renders_else_branch_when_fva_claim_is_absent(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_renders_else_branch_on_anonymous_request(): void
+    {
+        $body = $this->get('/render-mfa-anonymous')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
     }
 }

--- a/tests/Http/RequiresMfaTest.php
+++ b/tests/Http/RequiresMfaTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Http;
+
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+final class RequiresMfaTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware([AuthenticateWithAuthn::class, RequiresMfa::class])->get('/mfa-protected', function () {
+            return response()->json(['ok' => true]);
+        });
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_mfa:300'])->get('/mfa-protected-custom-age', function () {
+            return response()->json(['ok' => true]);
+        });
+
+        Route::middleware(RequiresMfa::class)->get('/mfa-only', function () {
+            return response()->json(['ok' => true]);
+        });
+    }
+
+    public function test_passes_when_second_factor_age_is_within_max_age(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 120]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected');
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+    }
+
+    public function test_redirects_to_factor_two_when_second_factor_was_never_proved(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, -1]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected');
+
+        $response->assertRedirect('/sign-in/factor-two');
+    }
+
+    public function test_redirects_to_factor_two_when_fva_claim_is_absent(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected');
+
+        $response->assertRedirect('/sign-in/factor-two');
+    }
+
+    public function test_redirects_to_factor_two_when_second_factor_age_exceeds_max_age(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 9000]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected');
+
+        $response->assertRedirect('/sign-in/factor-two');
+    }
+
+    public function test_redirects_to_sign_in_when_not_authenticated(): void
+    {
+        $response = $this->get('/mfa-only');
+
+        $response->assertRedirect('/sign-in');
+    }
+
+    public function test_respects_per_route_max_age_override_when_within_limit(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 200]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected-custom-age');
+
+        $response->assertOk();
+    }
+
+    public function test_respects_per_route_max_age_override_when_over_limit(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 400]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected-custom-age');
+
+        $response->assertRedirect('/sign-in/factor-two');
+    }
+
+    public function test_uses_configured_redirect_url_when_mfa_not_satisfied(): void
+    {
+        config(['authn.mfa.redirect_url' => '/auth/step-up']);
+
+        $jwt = $this->env->signJwt(['fva' => [60, -1]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/mfa-protected');
+
+        $response->assertRedirect('/auth/step-up');
+    }
+
+    public function test_uses_configured_sign_in_url_when_not_authenticated(): void
+    {
+        config(['authn.url.sign_in' => '/auth/sign-in']);
+
+        $response = $this->get('/mfa-only');
+
+        $response->assertRedirect('/auth/sign-in');
+    }
+}


### PR DESCRIPTION
Closes #8

## What

- **`RequiresMfa` route middleware** (alias `authn.requires_mfa`) — fail-close redirect when the verified session JWT lacks a recent second-factor proof:
  - No auth (`authn.claims` absent) → redirect to `config('authn.url.sign_in', '/sign-in')`
  - Auth but `secondFactorAgeSeconds` is `null` or exceeds the threshold → redirect to `config('authn.mfa.redirect_url', '/sign-in/factor-two')`
  - Per-route freshness override via Laravel's standard `:arg` syntax: `'authn.requires_mfa:300'`
- **`@authnRequiresMfa` Blade directive** — argument-free `Blade::if` that returns `true` when `VerifiedClaims->twoFactorVerified === true`
- **Config additions** to `config/authn.php`:
  - `authn.url.sign_in` (env `AUTHN_URL_SIGN_IN`, default `/sign-in`)
  - `authn.mfa.max_age_seconds` (env `AUTHN_MFA_MAX_AGE_SECONDS`, default `1800`)
  - `authn.mfa.redirect_url` (env `AUTHN_MFA_REDIRECT_URL`, default `/sign-in/factor-two`)
- **sdk-php constraint** bumped to `^0.2 || dev-main`; `minimum-stability` lifted to `dev` with `prefer-stable: true`; `branch-alias` bumped to `0.3.x-dev`

## Test plan

- [x] `RequiresMfaTest` — 9 cases covering: pass-through, redirect on absent/stale second-factor, unauthenticated redirect, per-route override, configurable redirect URLs
- [x] `BladeDirectivesTest` — 4 new cases for `@authnRequiresMfa`
- [x] 56 tests passed, PHPStan clean, pint clean