### PR TITLE
Bump for v0.3.0: tighten authn-sh/sdk-php constraint to ^0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.0] — 2026-05-10
+
+### Added
+
+- `@authnRequiresMfa` Blade directive — fail-close check that the verified `__session` JWT carries `twoFactorVerified === true`.
+- `RequiresMfa` route middleware (alias `authn.requires_mfa`) — fail-close redirect to `/sign-in/factor-two` when the session lacks a recent second-factor proof. Configurable freshness window via `config('authn.mfa.max_age_seconds')` (default 1800) or per-route override (`'authn.requires_mfa:300'`).
+- `config('authn.mfa.redirect_url')` — Account Portal factor-two URL (default `/sign-in/factor-two`).
+- `Authn::hasMfa()` / `Authn::secondFactorAgeSeconds()` facade helpers.
+
+### Changed
+
+- `authn-sh/sdk-php` constraint pinned to `^0.3` (was `dev-main || ^0.2`). Drops the dev-only VCS repository entry + `minimum-stability: dev` workaround that bridged the v0.2 alpha cycle.
+
 ## [0.2.0] — 2026-05-10
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "dev-main || ^0.3",
+        "authn-sh/sdk-php": "^0.3",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -48,12 +48,6 @@
         "pint": "vendor/bin/pint --test",
         "pint:fix": "vendor/bin/pint"
     },
-    "repositories": {
-        "sdk-php": {
-            "type": "vcs",
-            "url": "https://github.com/authn-sh/sdk-php"
-        }
-    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -74,6 +68,6 @@
             "dev-main": "0.3.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
## Summary

- Adds CHANGELOG entry for v0.3.0 (MFA-aware Blade directive + RequiresMfa middleware + config block).
- Tightens `authn-sh/sdk-php` constraint from `dev-main || ^0.3` to `^0.3` now that sdk-php@0.3.x is on Packagist.
- Drops the dev-only VCS repository entry + `minimum-stability: dev` workaround.

## Test plan

- [ ] CI green (will only go green after sdk-php@v0.3.0 is tagged and Packagist registers it).