### PR TITLE
feat(SPL-1): @authnHasConnectedAccount + RequiresConnectedAccount middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `@authnHasConnectedAccount('<provider_key>')` Blade directive. Renders the inner block when the active session JWT advertises an `ExternalAccount` linked to that provider.
+- `Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount` route middleware. Aliased as `authn.connected:<provider_key>`. Redirects to `authn.connected_accounts.redirect_url` (default `/sign-in/sso-callback?provider={provider}`) when the linked account is missing, and to `authn.url.sign_in` for unauthenticated requests.
+- `Authn\Sdk\Laravel\Support\ConnectedAccounts` helper exposing `providerKeys(VerifiedClaims)` and `has(VerifiedClaims, $providerKey)`. Reads `external_accounts[]` / `eac[]` from the JWT raw claim bag — both compact (`{p: "google"}` or string) and expanded (`{provider: "google", external_id: …}`) shapes are accepted.
+- `authn.connected_accounts.redirect_url` config key (env: `AUTHN_CONNECTED_REDIRECT_URL`, default `/sign-in/sso-callback?provider={provider}`).
+
+### Changed
+
+- Composer constraint on `authn-sh/sdk-php` bumped to `dev-main || ^0.4` with a VCS repository entry while v0.4 sits on alpha. Will be tightened to `^0.4` once `sdk-php@v0.4.0` is published.
+
 ## [0.3.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ Evaluates organization roles and permissions from the active session JWT:
 
 The argument must be prefixed with `role:` or `permission:`. Any other prefix raises an `InvalidArgumentException` at render time so typos fail loudly.
 
+### `@authnHasConnectedAccount`
+
+Renders the inner block when the active session JWT advertises an `ExternalAccount` linked to the named OAuth provider:
+
+```blade
+@authnHasConnectedAccount('google')
+    <p>Connected to Google.</p>
+@else
+    <a href="/sign-in/sso-callback?provider=google">Connect Google</a>
+@endauthnHasConnectedAccount
+```
+
+The matching route middleware `authn.connected:<provider_key>` fail-closes by redirecting to `authn.connected_accounts.redirect_url` (the `{provider}` placeholder is substituted with the route argument):
+
+```php
+Route::get('/integrations/google', [GoogleController::class, 'show'])
+    ->middleware(['authn', 'authn.connected:google']);
+```
+
 ## Facade methods
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,16 @@
         "issues": "https://github.com/authn-sh/sdk-php-laravel/issues",
         "source": "https://github.com/authn-sh/sdk-php-laravel"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.3",
+        "authn-sh/sdk-php": "dev-main || ^0.4",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -68,6 +74,6 @@
             "dev-main": "0.3.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/config/authn.php
+++ b/config/authn.php
@@ -104,4 +104,20 @@ return [
         'redirect_url' => env('AUTHN_MFA_REDIRECT_URL', '/sign-in/factor-two'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Connected accounts
+    |--------------------------------------------------------------------------
+    |
+    | `redirect_url` is where `RequiresConnectedAccount` sends a user that is
+    | signed in but missing the required `ExternalAccount` link. The
+    | `{provider}` placeholder is replaced with the route's `provider_key`
+    | parameter (e.g. `google`, `github`).
+    |
+    */
+
+    'connected_accounts' => [
+        'redirect_url' => env('AUTHN_CONNECTED_REDIRECT_URL', '/sign-in/sso-callback?provider={provider}'),
+    ],
+
 ];

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -6,7 +6,9 @@ namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
 use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
+use Authn\Sdk\Laravel\Support\ConnectedAccounts;
 use Authn\Sdk\Tokens\TokenVerifier;
 use Authn\Sdk\Tokens\VerifiedClaims;
 use Authn\Sdk\Webhooks\SignatureVerifier;
@@ -57,6 +59,7 @@ class AuthnServiceProvider extends ServiceProvider
         $router = $this->app->make('router');
         $router->aliasMiddleware('authn', AuthenticateWithAuthn::class);
         $router->aliasMiddleware('authn.requires_mfa', RequiresMfa::class);
+        $router->aliasMiddleware('authn.connected', RequiresConnectedAccount::class);
     }
 
     private function registerBladeDirectives(): void
@@ -65,6 +68,11 @@ class AuthnServiceProvider extends ServiceProvider
         Blade::if('authnSignedOut', fn (): bool => self::currentClaims() === null);
 
         Blade::if('authnRequiresMfa', fn (): bool => self::currentClaims()?->twoFactorVerified === true);
+
+        Blade::if(
+            'authnHasConnectedAccount',
+            fn (string $providerKey): bool => ConnectedAccounts::has(self::currentClaims(), $providerKey),
+        );
 
         Blade::if('authnHas', function (string $check): bool {
             if (str_starts_with($check, 'role:')) {

--- a/src/Http/Middleware/RequiresConnectedAccount.php
+++ b/src/Http/Middleware/RequiresConnectedAccount.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Http\Middleware;
+
+use Authn\Sdk\Laravel\Support\ConnectedAccounts;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Closure;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresConnectedAccount
+{
+    public function handle(Request $request, Closure $next, ?string $providerKey = null): Response
+    {
+        if ($providerKey === null || $providerKey === '') {
+            throw new InvalidArgumentException(
+                'authn.connected: provider_key parameter is required (e.g. authn.connected:google).',
+            );
+        }
+
+        $claims = $request->attributes->get(AuthenticateWithAuthn::REQUEST_ATTRIBUTE);
+
+        if (! $claims instanceof VerifiedClaims) {
+            $signInUrl = config('authn.url.sign_in');
+
+            return redirect(is_string($signInUrl) ? $signInUrl : '/sign-in');
+        }
+
+        if (ConnectedAccounts::has($claims, $providerKey)) {
+            /** @var Response $response */
+            $response = $next($request);
+
+            return $response;
+        }
+
+        $template = config('authn.connected_accounts.redirect_url');
+        $template = is_string($template) && $template !== ''
+            ? $template
+            : '/sign-in/sso-callback?provider={provider}';
+
+        return redirect(str_replace('{provider}', rawurlencode($providerKey), $template));
+    }
+}

--- a/src/Support/ConnectedAccounts.php
+++ b/src/Support/ConnectedAccounts.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Support;
+
+use Authn\Sdk\Tokens\VerifiedClaims;
+
+/**
+ * Reads the user's connected `ExternalAccount` rows out of a `VerifiedClaims`
+ * snapshot. Until the FAPI's session-token issuer surfaces an `external_accounts`
+ * snapshot in the JWT (tracked server-side), the helper falls back to scanning
+ * the raw claim bag for either of the agreed keys: `eac` or `external_accounts`.
+ * Both forms are accepted as a list of objects with a `provider` field that
+ * matches `OauthProvider.provider_key`.
+ */
+final class ConnectedAccounts
+{
+    /**
+     * @return list<string>
+     */
+    public static function providerKeys(?VerifiedClaims $claims): array
+    {
+        if ($claims === null) {
+            return [];
+        }
+
+        $rows = $claims->raw['external_accounts'] ?? $claims->raw['eac'] ?? null;
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        $keys = [];
+        foreach ($rows as $row) {
+            if (is_string($row)) {
+                $keys[] = $row;
+
+                continue;
+            }
+            if (! is_array($row)) {
+                continue;
+            }
+            $provider = $row['provider'] ?? $row['p'] ?? null;
+            if (is_string($provider) && $provider !== '') {
+                $keys[] = $provider;
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    public static function has(?VerifiedClaims $claims, string $providerKey): bool
+    {
+        return in_array($providerKey, self::providerKeys($claims), true);
+    }
+}

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -45,6 +45,14 @@ MFA_NOT_VERIFIED
 @endauthnRequiresMfa
 BLADE;
 
+    private const CONNECTED_TEMPLATE = <<<'BLADE'
+@authnHasConnectedAccount('google')
+HAS_GOOGLE
+@else
+NO_GOOGLE
+@endauthnHasConnectedAccount
+BLADE;
+
     private AuthnTestEnvironment $env;
 
     protected function setUp(): void
@@ -77,6 +85,13 @@ BLADE;
         );
 
         Route::get('/render-mfa-anonymous', fn () => Blade::render(self::MFA_TEMPLATE));
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-connected',
+            fn () => Blade::render(self::CONNECTED_TEMPLATE),
+        );
+
+        Route::get('/render-connected-anonymous', fn () => Blade::render(self::CONNECTED_TEMPLATE));
     }
 
     public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
@@ -199,5 +214,51 @@ BLADE;
 
         $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
         $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_has_connected_account_renders_truthy_branch_when_provider_is_linked(): void
+    {
+        $jwt = $this->env->signJwt([
+            'external_accounts' => [
+                ['provider' => 'google'],
+            ],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-connected')->getContent();
+
+        $this->assertStringContainsString('HAS_GOOGLE', (string) $body);
+        $this->assertStringNotContainsString('NO_GOOGLE', (string) $body);
+    }
+
+    public function test_authn_has_connected_account_renders_else_branch_when_provider_is_not_linked(): void
+    {
+        $jwt = $this->env->signJwt([
+            'external_accounts' => [
+                ['provider' => 'github'],
+            ],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-connected')->getContent();
+
+        $this->assertStringContainsString('NO_GOOGLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_GOOGLE', (string) $body);
+    }
+
+    public function test_authn_has_connected_account_renders_else_branch_when_claim_is_absent(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-connected')->getContent();
+
+        $this->assertStringContainsString('NO_GOOGLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_GOOGLE', (string) $body);
+    }
+
+    public function test_authn_has_connected_account_renders_else_branch_on_anonymous_request(): void
+    {
+        $body = $this->get('/render-connected-anonymous')->getContent();
+
+        $this->assertStringContainsString('NO_GOOGLE', (string) $body);
+        $this->assertStringNotContainsString('HAS_GOOGLE', (string) $body);
     }
 }

--- a/tests/Http/RequiresConnectedAccountTest.php
+++ b/tests/Http/RequiresConnectedAccountTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Http;
+
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+final class RequiresConnectedAccountTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.connected:google'])->get('/connected-google', function () {
+            return response()->json(['ok' => true]);
+        });
+
+        Route::middleware([RequiresConnectedAccount::class . ':google'])->get('/connected-only', function () {
+            return response()->json(['ok' => true]);
+        });
+    }
+
+    public function test_passes_when_jwt_external_accounts_includes_provider_object_form(): void
+    {
+        $jwt = $this->env->signJwt([
+            'external_accounts' => [
+                ['provider' => 'google', 'external_id' => 'sub_1'],
+                ['provider' => 'github'],
+            ],
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+    }
+
+    public function test_passes_when_jwt_eac_uses_compact_form_with_p_key(): void
+    {
+        $jwt = $this->env->signJwt([
+            'eac' => [
+                ['p' => 'google'],
+                ['p' => 'github'],
+            ],
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertOk();
+    }
+
+    public function test_passes_when_jwt_external_accounts_is_a_list_of_strings(): void
+    {
+        $jwt = $this->env->signJwt(['external_accounts' => ['google', 'github']]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertOk();
+    }
+
+    public function test_redirects_to_sso_callback_when_provider_not_linked(): void
+    {
+        $jwt = $this->env->signJwt(['external_accounts' => [['provider' => 'github']]]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertRedirect('/sign-in/sso-callback?provider=google');
+    }
+
+    public function test_redirects_when_external_accounts_claim_is_absent(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertRedirect('/sign-in/sso-callback?provider=google');
+    }
+
+    public function test_redirects_to_sign_in_when_unauthenticated(): void
+    {
+        $response = $this->get('/connected-only');
+
+        $response->assertRedirect('/sign-in');
+    }
+
+    public function test_uses_configured_redirect_url_with_provider_placeholder(): void
+    {
+        config(['authn.connected_accounts.redirect_url' => '/connect/{provider}/start']);
+
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-google');
+
+        $response->assertRedirect('/connect/google/start');
+    }
+
+    public function test_uses_configured_sign_in_url_when_unauthenticated(): void
+    {
+        config(['authn.url.sign_in' => '/auth/sign-in']);
+
+        $response = $this->get('/connected-only');
+
+        $response->assertRedirect('/auth/sign-in');
+    }
+
+    public function test_throws_when_provider_key_parameter_is_missing(): void
+    {
+        Route::middleware([AuthenticateWithAuthn::class, RequiresConnectedAccount::class])->get('/connected-no-arg', function () {
+            return response()->json(['ok' => true]);
+        });
+
+        $jwt = $this->env->signJwt();
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")->get('/connected-no-arg');
+    }
+}


### PR DESCRIPTION
Closes #13.

## Summary

- New `@authnHasConnectedAccount('<provider_key>')` Blade directive — renders the inner block when the active session JWT advertises an `ExternalAccount` linked to that provider.
- New `Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount` route middleware (alias `authn.connected:<provider_key>`). Fail-closes by redirecting to `authn.connected_accounts.redirect_url` with the `{provider}` placeholder substituted; redirects unauthenticated requests to `authn.url.sign_in`. Throws `InvalidArgumentException` when invoked without the `provider_key` argument so typos surface early.
- New `Authn\Sdk\Laravel\Support\ConnectedAccounts` helper exposing `providerKeys(VerifiedClaims): list<string>` and `has(VerifiedClaims, $key): bool`. Reads `external_accounts[]` / `eac[]` out of the JWT raw claim bag; accepts compact (`{p: "google"}`, plain string) and expanded (`{provider: "google", external_id: …}`) row shapes.
- New `authn.connected_accounts.redirect_url` config key (env `AUTHN_CONNECTED_REDIRECT_URL`) defaulting to `/sign-in/sso-callback?provider={provider}`.
- README + CHANGELOG documentation.

## Composer constraint

Per `feedback_alpha_during_integration` and the SPL-1 issue's "alpha during integration; switch to stable when sdk-php@v0.4.0 is published" note: bumped `authn-sh/sdk-php` to `dev-main || ^0.4` with a VCS repository entry. Same workaround the v0.3 SPL-1 PR used. Will be tightened to `^0.4` once `sdk-php@v0.4.0` ships on Packagist.

## Server-side `external_accounts` claim

The FAPI's `SessionTokenIssuer` doesn't yet emit the `external_accounts` / `eac` claim — that's the same gap I flagged with `authn-sh/authn#153` for `pnv` / `dsf`. Until the server lands the claim, the directive + middleware fall through to their else / fail-close branches, which is the correct conservative behavior. The helper accepts three different row shapes today so whichever shape the server settles on (full object, compact `{p}`, plain string) just works without an SDK change.

## Test plan

- [x] `vendor/bin/pest` — 69 passed, 135 assertions.
- [x] `vendor/bin/phpstan analyse --no-progress` — clean.
- [x] `vendor/bin/pint --test` — clean.
- [x] New `RequiresConnectedAccountTest` covers all three claim shapes (object/compact/string), provider-not-linked redirect, absent-claim redirect, unauthenticated → sign-in redirect, configured-redirect-url placeholder substitution, and the missing-`provider_key` `InvalidArgumentException`.
- [x] Extended `BladeDirectivesTest` covers the truthy / falsy / claim-absent / anonymous branches.