### PR TITLE
Cut v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.4.0] — 2026-05-11
 
 ### Added
 
@@ -11,7 +11,7 @@
 
 ### Changed
 
-- Composer constraint on `authn-sh/sdk-php` bumped to `dev-main || ^0.4` with a VCS repository entry while v0.4 sits on alpha. Will be tightened to `^0.4` once `sdk-php@v0.4.0` is published.
+- `authn-sh/sdk-php` constraint tightened to `^0.4` (was `dev-main || ^0.4`). Drops the dev-only VCS repository entry + `minimum-stability: dev` workaround that bridged the v0.4 alpha cycle.
 
 ## [0.3.0] — 2026-05-10
 

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,10 @@
         "issues": "https://github.com/authn-sh/sdk-php-laravel/issues",
         "source": "https://github.com/authn-sh/sdk-php-laravel"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/authn-sh/sdk-php"
-        }
-    ],
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "dev-main || ^0.4",
+        "authn-sh/sdk-php": "^0.4",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
@@ -71,9 +65,9 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.3.x-dev"
+            "dev-main": "0.4.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
- Adds the v0.4.0 CHANGELOG entry (covers SPL-1: @authnHasConnectedAccount Blade directive + RequiresConnectedAccount middleware).
- Tightens `authn-sh/sdk-php` constraint `^0.3` → `^0.4`.
- Branch-alias bumped to `0.4.x-dev`.