### PR TITLE
SPL-1: @authnHasPasskey directive + RequiresPasskey middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
+      # v0.5 integration: pin sdk-php to dev-main while sdk-php@v0.5.0
+      # is not yet on Packagist. The composer.json constraint stays
+      # `"dev-main || ^0.4"`; this step forces resolution to dev-main
+      # so prefer-stable can't pick the older v0.4.0 release.
+      - name: Pin authn-sh/sdk-php to dev-main (v0.5 integration)
+        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
+
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `@authnHasPasskey[(<mode>)]` Blade directive. Renders the inner block based on the active session's passkey signal. Two modes: `verified` (default — matches when the current session was authenticated by a passkey first-factor) and `enrolled` (matches whenever the user has at least one verified passkey on file).
+- `Authn\Sdk\Laravel\Http\Middleware\RequiresPasskey` route middleware. Aliased as `authn.requires_passkey[:<mode>]`. Fail-closes by redirecting to `authn.url.sign_in` for unauthenticated requests and to `authn.passkey.enroll_url` for authenticated requests lacking the required passkey signal.
+- `Authn\Sdk\Laravel\Support\Passkeys` helper exposing `matches(?VerifiedClaims, string $mode): bool` and the `MODE_VERIFIED` / `MODE_ENROLLED` constants.
+- `Authn::hasPasskey(?string $mode = null)` facade helper. Honours the configured default strict mode when no argument is supplied.
+- `authn.passkey.enroll_url` config key (env: `AUTHN_PASSKEY_ENROLL_URL`, default `/user/security/passkeys`).
+- `authn.passkey.default_strict_mode` config key (env: `AUTHN_PASSKEY_DEFAULT_STRICT_MODE`, default `verified`).
+
 ## [0.4.0] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,14 +81,52 @@ Route::get('/integrations/google', [GoogleController::class, 'show'])
     ->middleware(['authn', 'authn.connected:google']);
 ```
 
+### `@authnHasPasskey`
+
+Renders the inner block based on the active session's passkey signal. Two modes:
+
+- `verified` (default) — matches when the current session was authenticated by a passkey first-factor (`VerifiedClaims::wasVerifiedByPasskey()`).
+- `enrolled` — matches whenever the user has at least one verified passkey on file (`VerifiedClaims::hasPasskey()`).
+
+```blade
+@authnHasPasskey
+    <a href="/account/api-keys">Manage API keys</a>
+@else
+    <p>This area requires a passkey sign-in.</p>
+@endauthnHasPasskey
+
+@authnHasPasskey('enrolled')
+    <p>You already have a passkey on file.</p>
+@else
+    <a href="/user/security/passkeys">Add your first passkey</a>
+@endauthnHasPasskey
+```
+
+The matching route middleware `authn.requires_passkey[:<mode>]` fail-closes by redirecting unauthenticated requests to `authn.url.sign_in` and signed-in-but-under-authenticated requests to `authn.passkey.enroll_url`:
+
+```php
+Route::get('/account/security', [SecurityController::class, 'show'])
+    ->middleware(['authn', 'authn.requires_passkey']);            // verified (default)
+
+Route::get('/account/api-keys', [ApiKeyController::class, 'index'])
+    ->middleware(['authn', 'authn.requires_passkey:verified']);
+
+Route::get('/account/passkey-required-area', [Controller::class, 'show'])
+    ->middleware(['authn', 'authn.requires_passkey:enrolled']);
+```
+
+The default mode is configurable via `authn.passkey.default_strict_mode` (env `AUTHN_PASSKEY_DEFAULT_STRICT_MODE`).
+
 ## Facade methods
 
 ```php
 use Authn\Sdk\Laravel\Facades\Authn;
 
-$claims = Authn::auth();          // ?VerifiedClaims — null outside an authn-authenticated request
-Authn::hasRole('org:admin');      // bool
-Authn::hasPermission('org:foo:bar'); // bool
+$claims = Authn::auth();              // ?VerifiedClaims — null outside an authn-authenticated request
+Authn::hasRole('org:admin');          // bool
+Authn::hasPermission('org:foo:bar');  // bool
+Authn::hasPasskey();                  // bool — defaults to the configured strict mode ("verified")
+Authn::hasPasskey('enrolled');        // bool — true when the user has any verified passkey
 ```
 
 ## Development

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,17 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.4",
+        "authn-sh/sdk-php": "dev-main || ^0.4",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
+        }
+    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -68,6 +74,6 @@
             "dev-main": "0.4.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/config/authn.php
+++ b/config/authn.php
@@ -120,4 +120,26 @@ return [
         'redirect_url' => env('AUTHN_CONNECTED_REDIRECT_URL', '/sign-in/sso-callback?provider={provider}'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Passkey enforcement
+    |--------------------------------------------------------------------------
+    |
+    | `enroll_url` is where `RequiresPasskey` sends a signed-in user whose
+    | session lacks the required passkey signal. `default_strict_mode` picks
+    | which check the middleware (and the `@authnHasPasskey` Blade directive)
+    | apply when no per-call argument is supplied. Two modes:
+    |
+    |   - `verified` — only matches when the current session was actually
+    |     authenticated by a passkey first-factor (`VerifiedClaims->passkeyVerified`).
+    |   - `enrolled` — matches whenever the user has at least one verified
+    |     passkey on file (`VerifiedClaims->passkeyCount > 0`).
+    |
+    */
+
+    'passkey' => [
+        'enroll_url' => env('AUTHN_PASSKEY_ENROLL_URL', '/user/security/passkeys'),
+        'default_strict_mode' => env('AUTHN_PASSKEY_DEFAULT_STRICT_MODE', 'verified'),
+    ],
+
 ];

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\Support\Passkeys;
 use Authn\Sdk\Resources\AllowlistIdentifiersManager;
 use Authn\Sdk\Resources\BlocklistIdentifiersManager;
 use Authn\Sdk\Resources\InstanceManager;
@@ -109,6 +110,27 @@ class AuthnManager
     public function hasPermission(string $key): bool
     {
         return $this->auth()?->hasPermission($key) ?? false;
+    }
+
+    public function hasPasskey(?string $mode = null): bool
+    {
+        $resolved = $mode ?? $this->configuredPasskeyMode();
+
+        return Passkeys::matches($this->auth(), $resolved);
+    }
+
+    private function configuredPasskeyMode(): string
+    {
+        if (! $this->container->bound('config')) {
+            return Passkeys::MODE_VERIFIED;
+        }
+
+        $configured = $this->container->make('config')->get('authn.passkey.default_strict_mode');
+        if (is_string($configured) && in_array($configured, [Passkeys::MODE_VERIFIED, Passkeys::MODE_ENROLLED], true)) {
+            return $configured;
+        }
+
+        return Passkeys::MODE_VERIFIED;
     }
 
     public function users(): UsersManager

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -8,7 +8,9 @@ use Authn\Sdk\Client;
 use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresPasskey;
 use Authn\Sdk\Laravel\Support\ConnectedAccounts;
+use Authn\Sdk\Laravel\Support\Passkeys;
 use Authn\Sdk\Tokens\TokenVerifier;
 use Authn\Sdk\Tokens\VerifiedClaims;
 use Authn\Sdk\Webhooks\SignatureVerifier;
@@ -60,6 +62,7 @@ class AuthnServiceProvider extends ServiceProvider
         $router->aliasMiddleware('authn', AuthenticateWithAuthn::class);
         $router->aliasMiddleware('authn.requires_mfa', RequiresMfa::class);
         $router->aliasMiddleware('authn.connected', RequiresConnectedAccount::class);
+        $router->aliasMiddleware('authn.requires_passkey', RequiresPasskey::class);
     }
 
     private function registerBladeDirectives(): void
@@ -72,6 +75,14 @@ class AuthnServiceProvider extends ServiceProvider
         Blade::if(
             'authnHasConnectedAccount',
             fn (string $providerKey): bool => ConnectedAccounts::has(self::currentClaims(), $providerKey),
+        );
+
+        Blade::if(
+            'authnHasPasskey',
+            fn (?string $mode = null): bool => Passkeys::matches(
+                self::currentClaims(),
+                $mode ?? self::configuredPasskeyMode(),
+            ),
         );
 
         Blade::if('authnHas', function (string $check): bool {
@@ -87,6 +98,16 @@ class AuthnServiceProvider extends ServiceProvider
                 "authnHas: unrecognised check \"{$check}\" — prefix with \"role:\" or \"permission:\".",
             );
         });
+    }
+
+    private static function configuredPasskeyMode(): string
+    {
+        $configured = config('authn.passkey.default_strict_mode');
+        if (is_string($configured) && in_array($configured, [Passkeys::MODE_VERIFIED, Passkeys::MODE_ENROLLED], true)) {
+            return $configured;
+        }
+
+        return Passkeys::MODE_VERIFIED;
     }
 
     private static function currentClaims(): ?VerifiedClaims

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Authn\Sdk\Resources\WebhookEndpointsManager webhookEndpoints()
  * @method static bool hasRole(string $key)
  * @method static bool hasPermission(string $key)
+ * @method static bool hasPasskey(?string $mode = null)
  * @method static void resolveUserUsing(?callable $resolver)
  *
  * @see AuthnManager

--- a/src/Http/Middleware/RequiresPasskey.php
+++ b/src/Http/Middleware/RequiresPasskey.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Http\Middleware;
+
+use Authn\Sdk\Laravel\Support\Passkeys;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Closure;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresPasskey
+{
+    public function handle(Request $request, Closure $next, ?string $mode = null): Response
+    {
+        $claims = $request->attributes->get(AuthenticateWithAuthn::REQUEST_ATTRIBUTE);
+
+        if (! $claims instanceof VerifiedClaims) {
+            $signInUrl = config('authn.url.sign_in');
+
+            return redirect(is_string($signInUrl) ? $signInUrl : '/sign-in');
+        }
+
+        $resolvedMode = $mode ?? $this->configuredDefaultMode();
+
+        if (! Passkeys::matches($claims, $resolvedMode)) {
+            $enrollUrl = config('authn.passkey.enroll_url');
+
+            return redirect(is_string($enrollUrl) && $enrollUrl !== ''
+                ? $enrollUrl
+                : '/user/security/passkeys');
+        }
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        return $response;
+    }
+
+    private function configuredDefaultMode(): string
+    {
+        $configured = config('authn.passkey.default_strict_mode');
+        if (! is_string($configured) || $configured === '') {
+            return Passkeys::MODE_VERIFIED;
+        }
+
+        if (! in_array($configured, [Passkeys::MODE_VERIFIED, Passkeys::MODE_ENROLLED], true)) {
+            throw new InvalidArgumentException(
+                "authn.passkey.default_strict_mode: unrecognised mode \"{$configured}\" — must be \"verified\" or \"enrolled\".",
+            );
+        }
+
+        return $configured;
+    }
+}

--- a/src/Support/Passkeys.php
+++ b/src/Support/Passkeys.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Support;
+
+use Authn\Sdk\Tokens\VerifiedClaims;
+use InvalidArgumentException;
+
+final class Passkeys
+{
+    public const MODE_VERIFIED = 'verified';
+
+    public const MODE_ENROLLED = 'enrolled';
+
+    public static function matches(?VerifiedClaims $claims, string $mode): bool
+    {
+        if ($claims === null) {
+            return false;
+        }
+
+        return match ($mode) {
+            self::MODE_VERIFIED => $claims->wasVerifiedByPasskey(),
+            self::MODE_ENROLLED => $claims->hasPasskey(),
+            default => throw new InvalidArgumentException(
+                "authn passkey mode: unrecognised mode \"{$mode}\" — must be \"verified\" or \"enrolled\".",
+            ),
+        };
+    }
+}

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -53,6 +53,22 @@ NO_GOOGLE
 @endauthnHasConnectedAccount
 BLADE;
 
+    private const PASSKEY_DEFAULT_TEMPLATE = <<<'BLADE'
+@authnHasPasskey
+HAS_PASSKEY
+@else
+NO_PASSKEY
+@endauthnHasPasskey
+BLADE;
+
+    private const PASSKEY_ENROLLED_TEMPLATE = <<<'BLADE'
+@authnHasPasskey('enrolled')
+HAS_PASSKEY
+@else
+NO_PASSKEY
+@endauthnHasPasskey
+BLADE;
+
     private AuthnTestEnvironment $env;
 
     protected function setUp(): void
@@ -92,6 +108,18 @@ BLADE;
         );
 
         Route::get('/render-connected-anonymous', fn () => Blade::render(self::CONNECTED_TEMPLATE));
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-passkey',
+            fn () => Blade::render(self::PASSKEY_DEFAULT_TEMPLATE),
+        );
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-passkey-enrolled',
+            fn () => Blade::render(self::PASSKEY_ENROLLED_TEMPLATE),
+        );
+
+        Route::get('/render-passkey-anonymous', fn () => Blade::render(self::PASSKEY_DEFAULT_TEMPLATE));
     }
 
     public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
@@ -260,5 +288,53 @@ BLADE;
 
         $this->assertStringContainsString('NO_GOOGLE', (string) $body);
         $this->assertStringNotContainsString('HAS_GOOGLE', (string) $body);
+    }
+
+    public function test_authn_has_passkey_default_renders_truthy_branch_when_session_is_passkey_verified(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => true, 'pkc' => 1]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-passkey')->getContent();
+
+        $this->assertStringContainsString('HAS_PASSKEY', (string) $body);
+        $this->assertStringNotContainsString('NO_PASSKEY', (string) $body);
+    }
+
+    public function test_authn_has_passkey_default_renders_else_branch_when_user_has_passkey_but_session_is_password_only(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 3]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-passkey')->getContent();
+
+        $this->assertStringContainsString('NO_PASSKEY', (string) $body);
+        $this->assertStringNotContainsString('HAS_PASSKEY', (string) $body);
+    }
+
+    public function test_authn_has_passkey_enrolled_renders_truthy_branch_when_user_has_any_passkey(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 1]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-passkey-enrolled')->getContent();
+
+        $this->assertStringContainsString('HAS_PASSKEY', (string) $body);
+        $this->assertStringNotContainsString('NO_PASSKEY', (string) $body);
+    }
+
+    public function test_authn_has_passkey_enrolled_renders_else_branch_when_passkey_count_is_zero(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 0]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-passkey-enrolled')->getContent();
+
+        $this->assertStringContainsString('NO_PASSKEY', (string) $body);
+        $this->assertStringNotContainsString('HAS_PASSKEY', (string) $body);
+    }
+
+    public function test_authn_has_passkey_renders_else_branch_on_anonymous_request(): void
+    {
+        $body = $this->get('/render-passkey-anonymous')->getContent();
+
+        $this->assertStringContainsString('NO_PASSKEY', (string) $body);
+        $this->assertStringNotContainsString('HAS_PASSKEY', (string) $body);
     }
 }

--- a/tests/HasPasskeyTest.php
+++ b/tests/HasPasskeyTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Illuminate\Support\Facades\Route;
+
+final class HasPasskeyTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-passkey-default', function () {
+            return response()->json(['result' => Authn::hasPasskey()]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-passkey-enrolled', function () {
+            return response()->json(['result' => Authn::hasPasskey('enrolled')]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-passkey-verified', function () {
+            return response()->json(['result' => Authn::hasPasskey('verified')]);
+        });
+    }
+
+    public function test_returns_true_when_session_is_passkey_verified(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => true, 'pkc' => 1]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-passkey-default')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_returns_false_in_default_mode_when_session_is_password_only(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 2]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-passkey-default')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_enrolled_mode_returns_true_for_any_passkey_count_above_zero(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 2]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-passkey-enrolled')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_returns_false_when_no_authn_middleware_has_run(): void
+    {
+        Route::get('/has-passkey-outside-middleware', function () {
+            return response()->json(['result' => Authn::hasPasskey()]);
+        });
+
+        $this->get('/has-passkey-outside-middleware')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_honours_configured_default_strict_mode(): void
+    {
+        config(['authn.passkey.default_strict_mode' => 'enrolled']);
+
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 1]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-passkey-default')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+}

--- a/tests/Http/RequiresPasskeyTest.php
+++ b/tests/Http/RequiresPasskeyTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Http;
+
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresPasskey;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+final class RequiresPasskeyTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_passkey'])
+            ->get('/passkey-default', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_passkey:verified'])
+            ->get('/passkey-verified', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_passkey:enrolled'])
+            ->get('/passkey-enrolled', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([RequiresPasskey::class . ':verified'])
+            ->get('/passkey-no-authn', fn () => response()->json(['ok' => true]));
+    }
+
+    public function test_default_mode_passes_when_session_is_passkey_verified(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => true, 'pkc' => 1]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+    }
+
+    public function test_default_mode_redirects_to_enroll_when_session_is_password_only(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+
+        $response->assertRedirect('/user/security/passkeys');
+    }
+
+    public function test_default_mode_redirects_to_enroll_when_user_has_passkeys_but_session_is_not_passkey_verified(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 2]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+
+        $response->assertRedirect('/user/security/passkeys');
+    }
+
+    public function test_verified_mode_requires_passkey_session(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => true, 'pkc' => 1]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-verified');
+
+        $response->assertOk();
+    }
+
+    public function test_enrolled_mode_passes_when_user_has_at_least_one_passkey_even_without_passkey_session(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 2]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-enrolled');
+
+        $response->assertOk();
+    }
+
+    public function test_enrolled_mode_redirects_when_passkey_count_is_zero(): void
+    {
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 0]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-enrolled');
+
+        $response->assertRedirect('/user/security/passkeys');
+    }
+
+    public function test_redirects_to_sign_in_when_unauthenticated(): void
+    {
+        $response = $this->get('/passkey-no-authn');
+
+        $response->assertRedirect('/sign-in');
+    }
+
+    public function test_uses_configured_enroll_url_when_blocked(): void
+    {
+        config(['authn.passkey.enroll_url' => '/security/keys']);
+
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+
+        $response->assertRedirect('/security/keys');
+    }
+
+    public function test_uses_configured_sign_in_url_when_unauthenticated(): void
+    {
+        config(['authn.url.sign_in' => '/auth/sign-in']);
+
+        $response = $this->get('/passkey-no-authn');
+
+        $response->assertRedirect('/auth/sign-in');
+    }
+
+    public function test_default_strict_mode_can_be_configured_to_enrolled(): void
+    {
+        config(['authn.passkey.default_strict_mode' => 'enrolled']);
+
+        $jwt = $this->env->signJwt(['pkv' => false, 'pkc' => 1]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+
+        $response->assertOk();
+    }
+
+    public function test_throws_when_default_strict_mode_is_garbage(): void
+    {
+        config(['authn.passkey.default_strict_mode' => 'unicorn']);
+
+        $jwt = $this->env->signJwt(['pkv' => true]);
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")->get('/passkey-default');
+    }
+}


### PR DESCRIPTION
## Summary

Adds passkey-aware Blade + middleware helpers mirroring the v0.3 `RequiresMfa` and v0.4 `RequiresConnectedAccount` patterns. Two modes:

- `verified` (default) — matches when the current session was authenticated by a passkey first-factor (`VerifiedClaims::wasVerifiedByPasskey()`).
- `enrolled` — matches whenever the user has at least one verified passkey on file (`VerifiedClaims::hasPasskey()`).

What landed:

- Blade `@authnHasPasskey[(<mode>)]` directive. Default mode comes from `authn.passkey.default_strict_mode`.
- `Http\Middleware\RequiresPasskey`, aliased as `authn.requires_passkey[:<mode>]`. Fail-closes to `authn.url.sign_in` (unauthenticated) and `authn.passkey.enroll_url` (signed-in-but-under-authenticated). Garbage mode strings raise `InvalidArgumentException`.
- `Support\Passkeys` helper with `MODE_VERIFIED` / `MODE_ENROLLED` constants and `matches(?VerifiedClaims, string $mode): bool`.
- `Authn::hasPasskey(?string $mode = null)` facade helper on `AuthnManager`.
- Config: `authn.passkey.enroll_url` (default `/user/security/passkeys`) and `authn.passkey.default_strict_mode` (default `verified`).

## Composer constraints (v0.5 integration)

Bumps `authn-sh/sdk-php` to `"dev-main || ^0.4"`, adds the VCS repository entry, and sets `minimum-stability: dev` so the package can resolve against sdk-php main where SP-3's passkey claims live. The release dance tightens the constraint to `^0.5` once sdk-php v0.5.0 is on Packagist — that step is owned by the team lead.

## Test plan

- [x] `composer test` — 90 passed (21 new tests across `RequiresPasskeyTest`, `HasPasskeyTest`, and `BladeDirectivesTest`; 173 assertions)
- [x] `composer phpstan` — clean (after adding the `hasPasskey` `@method` docblock to the `Authn` facade)
- [x] `composer pint` — clean

Test coverage:
- Middleware: default mode passes when session is passkey-verified; default mode redirects when password-only; default mode redirects when user has passkeys but the session is password-only; explicit `:verified` requires passkey session; explicit `:enrolled` matches when `pkc > 0`; explicit `:enrolled` redirects when `pkc == 0`; redirects to `authn.url.sign_in` when unauthenticated; honours configured `authn.passkey.enroll_url`; honours configured `authn.url.sign_in`; honours configured `default_strict_mode = enrolled`; throws on garbage `default_strict_mode`.
- Facade: `verified` default, `enrolled` mode, false outside middleware, honours configured default strict mode.
- Blade directive: 5 render branches covering both modes, the password-only session, the empty `pkc`, and the anonymous request.

Closes #16