### PR TITLE
Cut v0.5.0: tighten sdk-php constraint, drop dev-main workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,6 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
-      # v0.5 integration: pin sdk-php to dev-main while sdk-php@v0.5.0
-      # is not yet on Packagist. The composer.json constraint stays
-      # `"dev-main || ^0.4"`; this step forces resolution to dev-main
-      # so prefer-stable can't pick the older v0.4.0 release.
-      - name: Pin authn-sh/sdk-php to dev-main (v0.5 integration)
-        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
-
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.5.0] — 2026-05-11
 
 ### Added
 
@@ -10,6 +10,10 @@
 - `Authn::hasPasskey(?string $mode = null)` facade helper. Honours the configured default strict mode when no argument is supplied.
 - `authn.passkey.enroll_url` config key (env: `AUTHN_PASSKEY_ENROLL_URL`, default `/user/security/passkeys`).
 - `authn.passkey.default_strict_mode` config key (env: `AUTHN_PASSKEY_DEFAULT_STRICT_MODE`, default `verified`).
+
+### Changed
+
+- Composer constraint on `authn-sh/sdk-php` tightened to `^0.5` (was `dev-main || ^0.4`). Drops the dev-only VCS repository entry, the `minimum-stability: dev` workaround, and the matching "Pin authn-sh/sdk-php to dev-main" CI step — all of which bridged the v0.5 alpha cycle. `sdk-php@v0.5.0` is now on Packagist.
 
 ## [0.4.0] — 2026-05-11
 

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,11 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "dev-main || ^0.4",
+        "authn-sh/sdk-php": "^0.5",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/authn-sh/sdk-php"
-        }
-    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -71,9 +65,9 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.4.x-dev"
+            "dev-main": "0.5.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Step 4 of the v0.5.0 cross-repo release dance — sdk-php@v0.5.0 is on Packagist now.

- composer.json: `authn-sh/sdk-php` constraint tightened to `^0.5` (was `dev-main || ^0.4`)
- composer.json: drop the VCS repository entry pointing at github.com/authn-sh/sdk-php
- composer.json: `minimum-stability` flipped `dev` → `stable`
- composer.json: branch-alias rolled forward `0.4.x-dev` → `0.5.x-dev`
- .github/workflows/ci.yml: drop the 'Pin authn-sh/sdk-php to dev-main (v0.5 integration)' step

Closes the SPL-1 integration-state workarounds; CHANGELOG entry promoted from `Unreleased` to `[0.5.0] — 2026-05-11` with a Changed note covering the constraint tightening.