### PR TITLE
SPL-1: @authnHasEnterpriseAccount directive + RequiresEnterpriseSso middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
+      # v0.6 integration: pin sdk-php to dev-main while sdk-php@v0.6.0
+      # is not yet on Packagist. The composer.json constraint stays
+      # `"dev-main || ^0.5"`; this step forces resolution to dev-main
+      # so prefer-stable can't pick the older v0.5.x release.
+      - name: Pin authn-sh/sdk-php to dev-main (v0.6 integration)
+        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
+
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `@authnHasEnterpriseAccount[(<connection_id>)]` Blade directive. Renders the inner block based on the active session's enterprise-SSO signal. With no argument, applies the configured default strict mode (`verified` — current session was minted through an enterprise IdP; or `linked` — user has at least one linked `EnterpriseAccount`). With a connection-id argument, matches when the current session's `entcon` equals it OR the user has a linked `EnterpriseAccount` for that connection.
+- `Authn\Sdk\Laravel\Http\Middleware\RequiresEnterpriseSso` route middleware. Aliased as `authn.requires_enterprise_sso[:<mode>]`. Fail-closes by redirecting to `authn.url.sign_in` for unauthenticated requests and to `authn.enterprise_sso.redirect_url` for authenticated requests lacking the required enterprise-SSO signal.
+- `Authn\Sdk\Laravel\Support\EnterpriseAccounts` helper exposing `matches(?VerifiedClaims, string $mode): bool`, `hasConnection(?VerifiedClaims, $connectionId): bool`, `connectionIds(?VerifiedClaims): list<string>` and the `MODE_VERIFIED` / `MODE_LINKED` constants. Reads enterprise-account snapshots from the JWT raw claim bag (`enterprise_accounts[]` or `eac[]`, both objects with `enterprise_connection_id` and bare strings accepted).
+- `Authn::hasEnterpriseSso(?string $mode = null)` facade helper. Honours the configured default strict mode when no argument is supplied.
+- `authn.enterprise_sso.redirect_url` config key (env: `AUTHN_ENTERPRISE_SSO_REDIRECT_URL`, default `/sign-in/enterprise-sso`).
+- `authn.enterprise_sso.default_strict_mode` config key (env: `AUTHN_ENTERPRISE_SSO_DEFAULT_STRICT_MODE`, default `verified`).
+
+### Changed
+
+- Composer constraint on `authn-sh/sdk-php` widened to `dev-main || ^0.5` so CI can resolve against sdk-php main during the v0.6 alpha cycle. The VCS repository entry, `minimum-stability: dev`, the "Pin authn-sh/sdk-php to dev-main (v0.6 integration)" CI step, and the `0.6.x-dev` branch alias are restored. All four are torn down again when the release dance cuts v0.6.0.
+
 ## [0.5.0] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ Route::get('/account/passkey-required-area', [Controller::class, 'show'])
 
 The default mode is configurable via `authn.passkey.default_strict_mode` (env `AUTHN_PASSKEY_DEFAULT_STRICT_MODE`).
 
+### `@authnHasEnterpriseAccount`
+
+Renders the inner block based on the active session's enterprise-SSO signal. Two modes for the no-argument form:
+
+- `verified` (default) — matches when the current session was authenticated through an enterprise IdP (`VerifiedClaims->enterpriseConnectionId !== null`).
+- `linked` — matches whenever the user has at least one linked `EnterpriseAccount`, whether or not the current session is enterprise-SSO.
+
+```blade
+@authnHasEnterpriseAccount
+    <p>You signed in via enterprise SSO.</p>
+@else
+    <a href="/sign-in/enterprise-sso">Sign in with your organization</a>
+@endauthnHasEnterpriseAccount
+```
+
+With a connection-id argument, the directive matches when the active session's `enterpriseConnectionId` equals it OR when the user has a linked `EnterpriseAccount` for that connection:
+
+```blade
+@authnHasEnterpriseAccount('entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA')
+    <a href="/admin/enterprise">Org admin</a>
+@endauthnHasEnterpriseAccount
+```
+
+The matching route middleware `authn.requires_enterprise_sso[:<mode>]` fail-closes by redirecting unauthenticated requests to `authn.url.sign_in` and signed-in-but-under-authenticated requests to `authn.enterprise_sso.redirect_url`:
+
+```php
+Route::get('/workspace', [WorkspaceController::class, 'show'])
+    ->middleware(['authn', 'authn.requires_enterprise_sso']);            // verified (default)
+
+Route::get('/workspace/admin', [WorkspaceAdminController::class, 'show'])
+    ->middleware(['authn', 'authn.requires_enterprise_sso:verified']);
+
+Route::get('/workspace/profile', [ProfileController::class, 'show'])
+    ->middleware(['authn', 'authn.requires_enterprise_sso:linked']);
+```
+
+The default mode is configurable via `authn.enterprise_sso.default_strict_mode` (env `AUTHN_ENTERPRISE_SSO_DEFAULT_STRICT_MODE`).
+
 ## Facade methods
 
 ```php
@@ -127,6 +165,8 @@ Authn::hasRole('org:admin');          // bool
 Authn::hasPermission('org:foo:bar');  // bool
 Authn::hasPasskey();                  // bool — defaults to the configured strict mode ("verified")
 Authn::hasPasskey('enrolled');        // bool — true when the user has any verified passkey
+Authn::hasEnterpriseSso();            // bool — defaults to the configured strict mode ("verified")
+Authn::hasEnterpriseSso('linked');    // bool — true when the user has any linked EnterpriseAccount
 ```
 
 ## Development

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,17 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.5",
+        "authn-sh/sdk-php": "dev-main || ^0.5",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
+        }
+    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -65,9 +71,9 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.5.x-dev"
+            "dev-main": "0.6.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/config/authn.php
+++ b/config/authn.php
@@ -142,4 +142,29 @@ return [
         'default_strict_mode' => env('AUTHN_PASSKEY_DEFAULT_STRICT_MODE', 'verified'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Enterprise SSO enforcement
+    |--------------------------------------------------------------------------
+    |
+    | `redirect_url` is where `RequiresEnterpriseSso` sends a signed-in user
+    | whose session lacks the required enterprise-SSO signal. `default_strict_mode`
+    | picks which check the middleware (and the `@authnHasEnterpriseAccount`
+    | Blade directive's no-arg form) apply when no per-call argument is
+    | supplied. Two modes:
+    |
+    |   - `verified` — only matches when the current session was actually
+    |     authenticated through an enterprise IdP (`entcon` claim present on
+    |     the JWT, surfaced as `VerifiedClaims->enterpriseConnectionId`).
+    |   - `linked` — matches whenever the user has at least one
+    |     `EnterpriseAccount` linked (current session counts, plus any rows
+    |     surfaced via the JWT's `enterprise_accounts[]` snapshot).
+    |
+    */
+
+    'enterprise_sso' => [
+        'redirect_url' => env('AUTHN_ENTERPRISE_SSO_REDIRECT_URL', '/sign-in/enterprise-sso'),
+        'default_strict_mode' => env('AUTHN_ENTERPRISE_SSO_DEFAULT_STRICT_MODE', 'verified'),
+    ],
+
 ];

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\Support\EnterpriseAccounts;
 use Authn\Sdk\Laravel\Support\Passkeys;
 use Authn\Sdk\Resources\AllowlistIdentifiersManager;
 use Authn\Sdk\Resources\BlocklistIdentifiersManager;
@@ -119,6 +120,13 @@ class AuthnManager
         return Passkeys::matches($this->auth(), $resolved);
     }
 
+    public function hasEnterpriseSso(?string $mode = null): bool
+    {
+        $resolved = $mode ?? $this->configuredEnterpriseSsoMode();
+
+        return EnterpriseAccounts::matches($this->auth(), $resolved);
+    }
+
     private function configuredPasskeyMode(): string
     {
         if (! $this->container->bound('config')) {
@@ -131,6 +139,20 @@ class AuthnManager
         }
 
         return Passkeys::MODE_VERIFIED;
+    }
+
+    private function configuredEnterpriseSsoMode(): string
+    {
+        if (! $this->container->bound('config')) {
+            return EnterpriseAccounts::MODE_VERIFIED;
+        }
+
+        $configured = $this->container->make('config')->get('authn.enterprise_sso.default_strict_mode');
+        if (is_string($configured) && in_array($configured, [EnterpriseAccounts::MODE_VERIFIED, EnterpriseAccounts::MODE_LINKED], true)) {
+            return $configured;
+        }
+
+        return EnterpriseAccounts::MODE_VERIFIED;
     }
 
     public function users(): UsersManager

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -7,9 +7,11 @@ namespace Authn\Sdk\Laravel;
 use Authn\Sdk\Client;
 use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresEnterpriseSso;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresPasskey;
 use Authn\Sdk\Laravel\Support\ConnectedAccounts;
+use Authn\Sdk\Laravel\Support\EnterpriseAccounts;
 use Authn\Sdk\Laravel\Support\Passkeys;
 use Authn\Sdk\Tokens\TokenVerifier;
 use Authn\Sdk\Tokens\VerifiedClaims;
@@ -63,6 +65,7 @@ class AuthnServiceProvider extends ServiceProvider
         $router->aliasMiddleware('authn.requires_mfa', RequiresMfa::class);
         $router->aliasMiddleware('authn.connected', RequiresConnectedAccount::class);
         $router->aliasMiddleware('authn.requires_passkey', RequiresPasskey::class);
+        $router->aliasMiddleware('authn.requires_enterprise_sso', RequiresEnterpriseSso::class);
     }
 
     private function registerBladeDirectives(): void
@@ -83,6 +86,18 @@ class AuthnServiceProvider extends ServiceProvider
                 self::currentClaims(),
                 $mode ?? self::configuredPasskeyMode(),
             ),
+        );
+
+        Blade::if(
+            'authnHasEnterpriseAccount',
+            function (?string $connectionId = null): bool {
+                $claims = self::currentClaims();
+                if ($connectionId !== null && $connectionId !== '') {
+                    return EnterpriseAccounts::hasConnection($claims, $connectionId);
+                }
+
+                return EnterpriseAccounts::matches($claims, self::configuredEnterpriseSsoMode());
+            },
         );
 
         Blade::if('authnHas', function (string $check): bool {
@@ -108,6 +123,16 @@ class AuthnServiceProvider extends ServiceProvider
         }
 
         return Passkeys::MODE_VERIFIED;
+    }
+
+    private static function configuredEnterpriseSsoMode(): string
+    {
+        $configured = config('authn.enterprise_sso.default_strict_mode');
+        if (is_string($configured) && in_array($configured, [EnterpriseAccounts::MODE_VERIFIED, EnterpriseAccounts::MODE_LINKED], true)) {
+            return $configured;
+        }
+
+        return EnterpriseAccounts::MODE_VERIFIED;
     }
 
     private static function currentClaims(): ?VerifiedClaims

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasRole(string $key)
  * @method static bool hasPermission(string $key)
  * @method static bool hasPasskey(?string $mode = null)
+ * @method static bool hasEnterpriseSso(?string $mode = null)
  * @method static void resolveUserUsing(?callable $resolver)
  *
  * @see AuthnManager

--- a/src/Http/Middleware/RequiresEnterpriseSso.php
+++ b/src/Http/Middleware/RequiresEnterpriseSso.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Http\Middleware;
+
+use Authn\Sdk\Laravel\Support\EnterpriseAccounts;
+use Authn\Sdk\Tokens\VerifiedClaims;
+use Closure;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresEnterpriseSso
+{
+    public function handle(Request $request, Closure $next, ?string $mode = null): Response
+    {
+        $claims = $request->attributes->get(AuthenticateWithAuthn::REQUEST_ATTRIBUTE);
+
+        if (! $claims instanceof VerifiedClaims) {
+            $signInUrl = config('authn.url.sign_in');
+
+            return redirect(is_string($signInUrl) ? $signInUrl : '/sign-in');
+        }
+
+        $resolvedMode = $mode ?? $this->configuredDefaultMode();
+
+        if (! EnterpriseAccounts::matches($claims, $resolvedMode)) {
+            $redirectUrl = config('authn.enterprise_sso.redirect_url');
+
+            return redirect(is_string($redirectUrl) && $redirectUrl !== ''
+                ? $redirectUrl
+                : '/sign-in/enterprise-sso');
+        }
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        return $response;
+    }
+
+    private function configuredDefaultMode(): string
+    {
+        $configured = config('authn.enterprise_sso.default_strict_mode');
+        if (! is_string($configured) || $configured === '') {
+            return EnterpriseAccounts::MODE_VERIFIED;
+        }
+
+        if (! in_array($configured, [EnterpriseAccounts::MODE_VERIFIED, EnterpriseAccounts::MODE_LINKED], true)) {
+            throw new InvalidArgumentException(
+                "authn.enterprise_sso.default_strict_mode: unrecognised mode \"{$configured}\" — must be \"verified\" or \"linked\".",
+            );
+        }
+
+        return $configured;
+    }
+}

--- a/src/Support/EnterpriseAccounts.php
+++ b/src/Support/EnterpriseAccounts.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Support;
+
+use Authn\Sdk\Tokens\VerifiedClaims;
+use InvalidArgumentException;
+
+/**
+ * Reads the user's enterprise-SSO state out of a `VerifiedClaims` snapshot.
+ *
+ * Two modes:
+ *
+ * - `verified` — the *current session* was authenticated by an enterprise
+ *   IdP (the JWT carries the `entcon` claim emitted by AU-16).
+ * - `linked` — the user has **at least one** `EnterpriseAccount` linked, even
+ *   if the current session was minted via a different strategy. Until the
+ *   FAPI session-token issuer adds an `enterprise_accounts` snapshot to the
+ *   JWT, this falls back to scanning the raw claim bag for `enterprise_accounts`
+ *   or the short-form key `eac` (list of objects with `enterprise_connection_id`
+ *   keys, or plain strings carrying the connection id). A populated `entcon`
+ *   claim also counts as linked.
+ */
+final class EnterpriseAccounts
+{
+    public const MODE_VERIFIED = 'verified';
+
+    public const MODE_LINKED = 'linked';
+
+    public static function matches(?VerifiedClaims $claims, string $mode): bool
+    {
+        if ($claims === null) {
+            return false;
+        }
+
+        return match ($mode) {
+            self::MODE_VERIFIED => $claims->wasVerifiedByEnterpriseSso(),
+            self::MODE_LINKED => $claims->wasVerifiedByEnterpriseSso() || self::connectionIds($claims) !== [],
+            default => throw new InvalidArgumentException(
+                "authn enterprise SSO mode: unrecognised mode \"{$mode}\" — must be \"verified\" or \"linked\".",
+            ),
+        };
+    }
+
+    /**
+     * True iff the active session's `enterpriseConnectionId` equals
+     * `$connectionId`, or the user has a linked `EnterpriseAccount` for it.
+     */
+    public static function hasConnection(?VerifiedClaims $claims, string $connectionId): bool
+    {
+        if ($claims === null) {
+            return false;
+        }
+
+        if ($claims->enterpriseConnectionId === $connectionId) {
+            return true;
+        }
+
+        return in_array($connectionId, self::connectionIds($claims), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function connectionIds(?VerifiedClaims $claims): array
+    {
+        if ($claims === null) {
+            return [];
+        }
+
+        $rows = $claims->raw['enterprise_accounts'] ?? $claims->raw['eac'] ?? null;
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($rows as $row) {
+            if (is_string($row) && $row !== '') {
+                $ids[] = $row;
+
+                continue;
+            }
+            if (! is_array($row)) {
+                continue;
+            }
+            $id = $row['enterprise_connection_id'] ?? $row['ec'] ?? null;
+            if (is_string($id) && $id !== '') {
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -69,6 +69,22 @@ NO_PASSKEY
 @endauthnHasPasskey
 BLADE;
 
+    private const ENTERPRISE_DEFAULT_TEMPLATE = <<<'BLADE'
+@authnHasEnterpriseAccount
+HAS_ENTERPRISE
+@else
+NO_ENTERPRISE
+@endauthnHasEnterpriseAccount
+BLADE;
+
+    private const ENTERPRISE_CONNECTION_TEMPLATE = <<<'BLADE'
+@authnHasEnterpriseAccount('entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA')
+HAS_ENTERPRISE
+@else
+NO_ENTERPRISE
+@endauthnHasEnterpriseAccount
+BLADE;
+
     private AuthnTestEnvironment $env;
 
     protected function setUp(): void
@@ -120,6 +136,18 @@ BLADE;
         );
 
         Route::get('/render-passkey-anonymous', fn () => Blade::render(self::PASSKEY_DEFAULT_TEMPLATE));
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-enterprise',
+            fn () => Blade::render(self::ENTERPRISE_DEFAULT_TEMPLATE),
+        );
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-enterprise-connection',
+            fn () => Blade::render(self::ENTERPRISE_CONNECTION_TEMPLATE),
+        );
+
+        Route::get('/render-enterprise-anonymous', fn () => Blade::render(self::ENTERPRISE_DEFAULT_TEMPLATE));
     }
 
     public function test_renders_the_signed_in_branch_when_middleware_has_populated_claims(): void
@@ -336,5 +364,72 @@ BLADE;
 
         $this->assertStringContainsString('NO_PASSKEY', (string) $body);
         $this->assertStringNotContainsString('HAS_PASSKEY', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_default_renders_truthy_branch_when_session_carries_entcon(): void
+    {
+        $jwt = $this->env->signJwt(['entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA']);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-enterprise')->getContent();
+
+        $this->assertStringContainsString('HAS_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('NO_ENTERPRISE', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_default_renders_else_branch_when_session_is_password_only(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-enterprise')->getContent();
+
+        $this->assertStringContainsString('NO_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ENTERPRISE', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_with_arg_matches_current_sessions_entcon(): void
+    {
+        $jwt = $this->env->signJwt(['entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA']);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-enterprise-connection')->getContent();
+
+        $this->assertStringContainsString('HAS_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('NO_ENTERPRISE', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_with_arg_matches_linked_account_for_that_connection(): void
+    {
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-enterprise-connection')->getContent();
+
+        $this->assertStringContainsString('HAS_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('NO_ENTERPRISE', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_with_arg_renders_else_branch_for_other_connection(): void
+    {
+        $jwt = $this->env->signJwt([
+            'entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZZ',
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZZ'],
+            ],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-enterprise-connection')->getContent();
+
+        $this->assertStringContainsString('NO_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ENTERPRISE', (string) $body);
+    }
+
+    public function test_authn_has_enterprise_account_renders_else_branch_on_anonymous_request(): void
+    {
+        $body = $this->get('/render-enterprise-anonymous')->getContent();
+
+        $this->assertStringContainsString('NO_ENTERPRISE', (string) $body);
+        $this->assertStringNotContainsString('HAS_ENTERPRISE', (string) $body);
     }
 }

--- a/tests/HasEnterpriseSsoTest.php
+++ b/tests/HasEnterpriseSsoTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Illuminate\Support\Facades\Route;
+
+final class HasEnterpriseSsoTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-enterprise-default', function () {
+            return response()->json(['result' => Authn::hasEnterpriseSso()]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-enterprise-linked', function () {
+            return response()->json(['result' => Authn::hasEnterpriseSso('linked')]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-enterprise-verified', function () {
+            return response()->json(['result' => Authn::hasEnterpriseSso('verified')]);
+        });
+    }
+
+    public function test_returns_true_when_session_was_enterprise_sso_verified(): void
+    {
+        $jwt = $this->env->signJwt(['entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA']);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-enterprise-default')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_returns_false_in_default_mode_when_session_is_password_only_even_with_linked_accounts(): void
+    {
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-enterprise-default')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_linked_mode_returns_true_when_user_has_any_linked_enterprise_account(): void
+    {
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-enterprise-linked')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_returns_false_when_no_authn_middleware_has_run(): void
+    {
+        Route::get('/has-enterprise-outside-middleware', function () {
+            return response()->json(['result' => Authn::hasEnterpriseSso()]);
+        });
+
+        $this->get('/has-enterprise-outside-middleware')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_honours_configured_default_strict_mode(): void
+    {
+        config(['authn.enterprise_sso.default_strict_mode' => 'linked']);
+
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-enterprise-default')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+}

--- a/tests/Http/RequiresEnterpriseSsoTest.php
+++ b/tests/Http/RequiresEnterpriseSsoTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests\Http;
+
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Http\Middleware\RequiresEnterpriseSso;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Authn\Sdk\Laravel\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+final class RequiresEnterpriseSsoTest extends TestCase
+{
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_enterprise_sso'])
+            ->get('/sso-default', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_enterprise_sso:verified'])
+            ->get('/sso-verified', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([AuthenticateWithAuthn::class, 'authn.requires_enterprise_sso:linked'])
+            ->get('/sso-linked', fn () => response()->json(['ok' => true]));
+
+        Route::middleware([RequiresEnterpriseSso::class . ':verified'])
+            ->get('/sso-no-authn', fn () => response()->json(['ok' => true]));
+    }
+
+    public function test_default_mode_passes_when_session_carries_entcon(): void
+    {
+        $jwt = $this->env->signJwt([
+            'entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+            'entacc' => 'entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-default');
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+    }
+
+    public function test_default_mode_redirects_when_session_is_password_only(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-default');
+
+        $response->assertRedirect('/sign-in/enterprise-sso');
+    }
+
+    public function test_verified_mode_requires_entcon_on_the_current_session(): void
+    {
+        $jwt = $this->env->signJwt([
+            'entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-verified');
+
+        $response->assertOk();
+    }
+
+    public function test_verified_mode_rejects_even_if_user_has_linked_accounts_but_session_is_not_enterprise(): void
+    {
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-verified');
+
+        $response->assertRedirect('/sign-in/enterprise-sso');
+    }
+
+    public function test_linked_mode_passes_when_user_has_at_least_one_linked_account_even_without_entcon(): void
+    {
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-linked');
+
+        $response->assertOk();
+    }
+
+    public function test_linked_mode_passes_when_session_carries_entcon_only(): void
+    {
+        $jwt = $this->env->signJwt([
+            'entcon' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-linked');
+
+        $response->assertOk();
+    }
+
+    public function test_linked_mode_redirects_when_user_has_no_enterprise_accounts(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-linked');
+
+        $response->assertRedirect('/sign-in/enterprise-sso');
+    }
+
+    public function test_redirects_to_sign_in_when_unauthenticated(): void
+    {
+        $response = $this->get('/sso-no-authn');
+
+        $response->assertRedirect('/sign-in');
+    }
+
+    public function test_uses_configured_redirect_url_when_blocked(): void
+    {
+        config(['authn.enterprise_sso.redirect_url' => '/auth/enterprise-start']);
+
+        $jwt = $this->env->signJwt();
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-default');
+
+        $response->assertRedirect('/auth/enterprise-start');
+    }
+
+    public function test_uses_configured_sign_in_url_when_unauthenticated(): void
+    {
+        config(['authn.url.sign_in' => '/auth/sign-in']);
+
+        $response = $this->get('/sso-no-authn');
+
+        $response->assertRedirect('/auth/sign-in');
+    }
+
+    public function test_default_strict_mode_can_be_configured_to_linked(): void
+    {
+        config(['authn.enterprise_sso.default_strict_mode' => 'linked']);
+
+        $jwt = $this->env->signJwt([
+            'enterprise_accounts' => [
+                ['enterprise_connection_id' => 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA'],
+            ],
+        ]);
+
+        $response = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-default');
+
+        $response->assertOk();
+    }
+
+    public function test_throws_when_default_strict_mode_is_garbage(): void
+    {
+        config(['authn.enterprise_sso.default_strict_mode' => 'unicorn']);
+
+        $jwt = $this->env->signJwt(['entcon' => 'entcon_x']);
+
+        $this->withoutExceptionHandling();
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")->get('/sso-default');
+    }
+}


### PR DESCRIPTION
Closes #19

## Summary

Adds enterprise-SSO-aware Blade + middleware helpers mirroring the v0.3 `RequiresMfa`, v0.4 `RequiresConnectedAccount`, and v0.5 `RequiresPasskey` patterns. Two modes:

- `verified` (default) — matches when the current session was authenticated through an enterprise IdP (parsed from `entcon`, surfaced as `VerifiedClaims->enterpriseConnectionId`).
- `linked` — matches whenever the user has at least one linked `EnterpriseAccount` on file (current session counts, plus any rows surfaced through the JWT's `enterprise_accounts[]` snapshot).

### What landed

- Blade `@authnHasEnterpriseAccount[(<connection_id>)]` directive. No-argument form applies the configured default strict mode. With-argument form matches when the current session's `entcon` equals the supplied id OR the user has a linked `EnterpriseAccount` for that connection.
- `Http\Middleware\RequiresEnterpriseSso`, aliased as `authn.requires_enterprise_sso[:<mode>]`. Fail-closes by redirecting unauthenticated requests to `authn.url.sign_in` and signed-in-but-under-authenticated requests to `authn.enterprise_sso.redirect_url` (default `/sign-in/enterprise-sso`).
- `Support\EnterpriseAccounts` helper with `MODE_VERIFIED` / `MODE_LINKED` constants and `matches/hasConnection/connectionIds`. Reads the JWT raw claim bag (`enterprise_accounts` or short-form `eac`) when asked about linked connections.
- `Authn::hasEnterpriseSso(?string $mode = null)` facade helper.
- Config keys `authn.enterprise_sso.redirect_url` and `authn.enterprise_sso.default_strict_mode`.
- README documents both the directive and the middleware; CHANGELOG gets an Unreleased section for v0.6.

### Composer / CI integration setup

Widens `authn-sh/sdk-php` from `^0.5` to `"dev-main || ^0.5"` and re-adds the VCS repository entry, `minimum-stability: dev`, the "Pin authn-sh/sdk-php to dev-main (v0.6 integration)" CI step, and the `0.6.x-dev` branch alias. All four are needed during the v0.6 alpha cycle so phpstan and the test suite can resolve against sdk-php main where SP-3's `VerifiedClaims->enterpriseConnectionId` / `->enterpriseAccountId` live. **Team-lead drives the release-dance tightening to `^0.6` later — not in this PR.**

## Test plan

- [x] `composer pint` — clean
- [x] `composer phpstan` — no errors (with sdk-php pinned to dev-main)
- [x] `composer test` — 113 passed (214 assertions); new files cover both modes, default-mode resolution, the unauthenticated-redirect path, the redirect-URL override, the `default_strict_mode = linked` config path, the garbage-mode error path, the facade helper (including outside-middleware behaviour), and six new Blade-directive render branches.