### PR TITLE
Cut v0.6.0: tighten sdk-php constraint, drop dev-main workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,6 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
-      # v0.6 integration: pin sdk-php to dev-main while sdk-php@v0.6.0
-      # is not yet on Packagist. The composer.json constraint stays
-      # `"dev-main || ^0.5"`; this step forces resolution to dev-main
-      # so prefer-stable can't pick the older v0.5.x release.
-      - name: Pin authn-sh/sdk-php to dev-main (v0.6 integration)
-        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
-
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] — 2026-05-12
 
 ### Added
 
@@ -10,6 +10,10 @@
 - `Authn::hasEnterpriseSso(?string $mode = null)` facade helper. Honours the configured default strict mode when no argument is supplied.
 - `authn.enterprise_sso.redirect_url` config key (env: `AUTHN_ENTERPRISE_SSO_REDIRECT_URL`, default `/sign-in/enterprise-sso`).
 - `authn.enterprise_sso.default_strict_mode` config key (env: `AUTHN_ENTERPRISE_SSO_DEFAULT_STRICT_MODE`, default `verified`).
+
+### Changed
+
+- Composer constraint on `authn-sh/sdk-php` tightened to `^0.6` (was `dev-main || ^0.5`). Drops the dev-only VCS repository entry, the `minimum-stability: dev` workaround, and the matching "Pin authn-sh/sdk-php to dev-main" CI step — all of which bridged the v0.6 alpha cycle. `sdk-php@v0.6.0` is now on Packagist.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,11 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "dev-main || ^0.5",
+        "authn-sh/sdk-php": "^0.6",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/authn-sh/sdk-php"
-        }
-    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -74,6 +68,6 @@
             "dev-main": "0.6.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Step 4 of the v0.6.0 cross-repo release dance — sdk-php@v0.6.0 is on Packagist now.

- composer.json: `authn-sh/sdk-php` constraint tightened to `^0.6` (was `dev-main || ^0.5`)
- composer.json: drop the VCS repository entry pointing at github.com/authn-sh/sdk-php
- composer.json: `minimum-stability` flipped `dev` → `stable`
- .github/workflows/ci.yml: drop the 'Pin authn-sh/sdk-php to dev-main (v0.6 integration)' step
- CHANGELOG: `Unreleased` → `[0.6.0] — 2026-05-12` with a Changed note covering the constraint tightening.