### PR TITLE
SPL-1: @authnHasAuthorizedApp Blade directive + facade helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
+      # v0.7 integration: pin sdk-php to dev-main while sdk-php@v0.7.0
+      # is not yet on Packagist. The composer.json constraint stays
+      # `"dev-main || ^0.6"`; this step forces resolution to dev-main
+      # so prefer-stable can't pick the older v0.6.0 release.
+      - name: Pin authn-sh/sdk-php to dev-main (v0.7 integration)
+        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
+
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `@authnHasAuthorizedApp('<oauth_application_id>')` Blade directive. Renders the inner block when the active session has an active `AuthorizationGrant` for the supplied `OauthApplication.id` (the row id `oac_*`, not the public `oac_pub_*` client id). Useful for gating dashboards or routes by per-app consent state.
+- `Authn::hasAuthorizedApp(string $appId)` facade helper exposed by `AuthnManager::hasAuthorizedApp()`.
+- `Authn\Sdk\Laravel\Support\AuthorizedApps` helper exposing `has(?VerifiedClaims, string $appId): bool` and `granted(?VerifiedClaims): list<string>`. Reads the `authorized_apps[]` claim through `VerifiedClaims->customClaim('authorized_apps')` and tolerates non-string entries by filtering them out.
+
+### Notes
+
+- v0.7 ships forward-compat: the server does not yet emit the `authorized_apps[]` claim on session JWTs, so the directive and helper resolve to `false` for every grant in v0.7. The API surface is stable across the transition — once the claim emission lands, existing templates start gating correctly without consumer changes. Tracked in a v0.8 follow-up against `authn-sh/authn`.
+
+### Changed
+
+- Composer constraint on `authn-sh/sdk-php` widened to `dev-main || ^0.6` so CI can resolve against sdk-php main during the v0.7 alpha cycle. The VCS repository entry, `minimum-stability: dev`, and the "Pin authn-sh/sdk-php to dev-main (v0.7 integration)" CI step are restored. All three are torn down again when the release dance cuts v0.7.0.
+
 ## [0.6.0] — 2026-05-12
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,17 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "^0.6",
+        "authn-sh/sdk-php": "dev-main || ^0.6",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/authn-sh/sdk-php"
+        }
+    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -68,6 +74,6 @@
             "dev-main": "0.6.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/AuthnManager.php
+++ b/src/AuthnManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Authn\Sdk\Laravel;
 
 use Authn\Sdk\Client;
+use Authn\Sdk\Laravel\Support\AuthorizedApps;
 use Authn\Sdk\Laravel\Support\EnterpriseAccounts;
 use Authn\Sdk\Laravel\Support\Passkeys;
 use Authn\Sdk\Resources\AllowlistIdentifiersManager;
@@ -125,6 +126,18 @@ class AuthnManager
         $resolved = $mode ?? $this->configuredEnterpriseSsoMode();
 
         return EnterpriseAccounts::matches($this->auth(), $resolved);
+    }
+
+    /**
+     * True iff the active session has an active `AuthorizationGrant` for the
+     * supplied `OauthApplication.id`. v0.7 ships forward-compat — the server
+     * does not yet emit the `authorized_apps[]` claim on session JWTs, so this
+     * resolves to `false` for every grant in v0.7. Becomes functional in a
+     * later release without consumer changes.
+     */
+    public function hasAuthorizedApp(string $appId): bool
+    {
+        return AuthorizedApps::has($this->auth(), $appId);
     }
 
     private function configuredPasskeyMode(): string

--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -10,6 +10,7 @@ use Authn\Sdk\Laravel\Http\Middleware\RequiresConnectedAccount;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresEnterpriseSso;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresMfa;
 use Authn\Sdk\Laravel\Http\Middleware\RequiresPasskey;
+use Authn\Sdk\Laravel\Support\AuthorizedApps;
 use Authn\Sdk\Laravel\Support\ConnectedAccounts;
 use Authn\Sdk\Laravel\Support\EnterpriseAccounts;
 use Authn\Sdk\Laravel\Support\Passkeys;
@@ -98,6 +99,11 @@ class AuthnServiceProvider extends ServiceProvider
 
                 return EnterpriseAccounts::matches($claims, self::configuredEnterpriseSsoMode());
             },
+        );
+
+        Blade::if(
+            'authnHasAuthorizedApp',
+            fn (string $appId): bool => AuthorizedApps::has(self::currentClaims(), $appId),
         );
 
         Blade::if('authnHas', function (string $check): bool {

--- a/src/Facades/Authn.php
+++ b/src/Facades/Authn.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasPermission(string $key)
  * @method static bool hasPasskey(?string $mode = null)
  * @method static bool hasEnterpriseSso(?string $mode = null)
+ * @method static bool hasAuthorizedApp(string $appId)
  * @method static void resolveUserUsing(?callable $resolver)
  *
  * @see AuthnManager

--- a/src/Support/AuthorizedApps.php
+++ b/src/Support/AuthorizedApps.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Support;
+
+use Authn\Sdk\Tokens\VerifiedClaims;
+
+/**
+ * Reads the user's `AuthorizationGrant` state out of a `VerifiedClaims`
+ * snapshot — driving the `@authnHasAuthorizedApp` Blade directive and the
+ * `Authn::hasAuthorizedApp($appId)` facade helper.
+ *
+ * v0.7 ships forward-compat: consumers register the directive against an
+ * `OauthApplication.id` (`oac_*`) and the helper resolves to `false` for
+ * every grant until the server emits the `authorized_apps[]` claim on
+ * session JWTs (tracked as a v0.8 follow-up against the `authn` repo). The
+ * directive API surface is stable across that transition — once the claim
+ * lands, the same templates start gating correctly without consumer
+ * changes.
+ *
+ * The claim shape, when emitted, is a flat list of `OauthApplication.id`
+ * strings (the row id `oac_*`, not the public `oac_pub_*` client id), one
+ * entry per active grant for the active session's user. Revoked grants are
+ * filtered out at issue time, so a present id always means an active
+ * grant.
+ */
+final class AuthorizedApps
+{
+    /**
+     * True iff the verified claim set carries an active `AuthorizationGrant`
+     * for `$appId`. Returns `false` for null claims and for any claim set
+     * that doesn't yet carry the `authorized_apps` entry (the v0.7 default).
+     */
+    public static function has(?VerifiedClaims $claims, string $appId): bool
+    {
+        if ($claims === null || $appId === '') {
+            return false;
+        }
+
+        return in_array($appId, self::granted($claims), true);
+    }
+
+    /**
+     * Returns every `OauthApplication.id` the verified user has actively
+     * granted to the active session. Empty list when the claim is absent
+     * or malformed. Order matches the server emission; duplicates are
+     * preserved (the server is responsible for de-duping at mint time).
+     *
+     * @return list<string>
+     */
+    public static function granted(?VerifiedClaims $claims): array
+    {
+        if ($claims === null) {
+            return [];
+        }
+
+        $value = $claims->customClaim('authorized_apps');
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item) && $item !== '') {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/tests/HasAuthorizedAppTest.php
+++ b/tests/HasAuthorizedAppTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Laravel\Tests;
+
+use Authn\Sdk\Laravel\Facades\Authn;
+use Authn\Sdk\Laravel\Http\Middleware\AuthenticateWithAuthn;
+use Authn\Sdk\Laravel\Tests\Support\AuthnTestEnvironment;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+
+final class HasAuthorizedAppTest extends TestCase
+{
+    private const DIRECTIVE_TEMPLATE = <<<'BLADE'
+@authnHasAuthorizedApp('oac_dashboard')
+HAS_DASHBOARD
+@else
+NO_DASHBOARD
+@endauthnHasAuthorizedApp
+BLADE;
+
+    private AuthnTestEnvironment $env;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env = new AuthnTestEnvironment;
+        $this->env->bind($this->app);
+
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-app-dashboard', function () {
+            return response()->json(['result' => Authn::hasAuthorizedApp('oac_dashboard')]);
+        });
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-authorized-app',
+            fn () => Blade::render(self::DIRECTIVE_TEMPLATE),
+        );
+
+        Route::get(
+            '/render-authorized-app-anonymous',
+            fn () => Blade::render(self::DIRECTIVE_TEMPLATE),
+        );
+    }
+
+    public function test_facade_returns_true_when_authorized_apps_carries_the_id(): void
+    {
+        $jwt = $this->env->signJwt([
+            'authorized_apps' => ['oac_dashboard', 'oac_mobile'],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-dashboard')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_facade_returns_false_when_authorized_apps_omits_the_id(): void
+    {
+        $jwt = $this->env->signJwt([
+            'authorized_apps' => ['oac_other'],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-dashboard')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_facade_returns_false_when_claim_absent_v07_default(): void
+    {
+        $jwt = $this->env->signJwt();
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-dashboard')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_facade_returns_false_when_authorized_apps_is_not_an_array(): void
+    {
+        $jwt = $this->env->signJwt(['authorized_apps' => 'oac_dashboard']);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-dashboard')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_facade_ignores_non_string_entries_in_authorized_apps(): void
+    {
+        $jwt = $this->env->signJwt([
+            'authorized_apps' => ['oac_dashboard', 42, ['nested' => 'oac_dashboard'], ''],
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-dashboard')
+            ->assertOk()
+            ->assertJson(['result' => true]);
+    }
+
+    public function test_blade_directive_renders_truthy_branch_when_app_is_granted(): void
+    {
+        $jwt = $this->env->signJwt([
+            'authorized_apps' => ['oac_dashboard'],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/render-authorized-app')
+            ->getContent();
+
+        $this->assertStringContainsString('HAS_DASHBOARD', (string) $body);
+        $this->assertStringNotContainsString('NO_DASHBOARD', (string) $body);
+    }
+
+    public function test_blade_directive_renders_else_branch_when_app_is_not_granted(): void
+    {
+        $jwt = $this->env->signJwt([
+            'authorized_apps' => ['oac_mobile'],
+        ]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/render-authorized-app')
+            ->getContent();
+
+        $this->assertStringContainsString('NO_DASHBOARD', (string) $body);
+        $this->assertStringNotContainsString('HAS_DASHBOARD', (string) $body);
+    }
+
+    public function test_blade_directive_renders_else_branch_for_anonymous_requests(): void
+    {
+        $body = $this->get('/render-authorized-app-anonymous')->getContent();
+
+        $this->assertStringContainsString('NO_DASHBOARD', (string) $body);
+        $this->assertStringNotContainsString('HAS_DASHBOARD', (string) $body);
+    }
+
+    public function test_returns_false_when_no_authn_middleware_has_run(): void
+    {
+        Route::get('/has-app-outside-middleware', function () {
+            return response()->json(['result' => Authn::hasAuthorizedApp('oac_dashboard')]);
+        });
+
+        $this->get('/has-app-outside-middleware')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+
+    public function test_returns_false_when_app_id_is_empty(): void
+    {
+        Route::middleware(AuthenticateWithAuthn::class)->get('/has-app-empty', function () {
+            return response()->json(['result' => Authn::hasAuthorizedApp('')]);
+        });
+
+        $jwt = $this->env->signJwt(['authorized_apps' => ['oac_dashboard']]);
+
+        $this->withHeader('Authorization', "Bearer {$jwt}")
+            ->get('/has-app-empty')
+            ->assertOk()
+            ->assertJson(['result' => false]);
+    }
+}


### PR DESCRIPTION
Closes #22.

Adds the v0.7 OAuth-provider-mode dashboard primitives so Laravel consumers can gate routes and template blocks by per-app consent state.

## What's in

- **\`@authnHasAuthorizedApp('<oauth_application_id>')\`** Blade directive. Renders the inner block when the active session has an active \`AuthorizationGrant\` for the supplied \`OauthApplication.id\` (the row id \`oac_*\`, not the public \`oac_pub_*\` client id). Standard \`@else\` / \`@endauthnHasAuthorizedApp\` are supported.
- **\`Authn::hasAuthorizedApp(string \$appId)\`** facade helper exposed by \`AuthnManager::hasAuthorizedApp()\`.
- **\`Authn\\\\Sdk\\\\Laravel\\\\Support\\\\AuthorizedApps\`** helper exposing \`has(?VerifiedClaims, string \$appId): bool\` and \`granted(?VerifiedClaims): list<string>\`. Reads the \`authorized_apps[]\` claim via \`VerifiedClaims->customClaim()\` (introduced in sdk-php SP-3) and tolerates non-string entries by filtering them out.

10 new Pest cases cover the happy path (id present), the negative path (id absent), claim-absent fallback, non-array claim malformation, mixed-type filtering, the Blade directive's truthy / else / anonymous branches, and the empty-id + middleware-skipped edge cases.

## Forward-compat — v0.7 ships without server emission

v0.7 server work does **not** emit \`authorized_apps[]\` on session JWTs, so the directive and helper resolve to \`false\` for every grant in v0.7. This is intentional — the API surface is stable across the transition, and once the claim emission lands the existing templates start gating correctly without consumer changes. Tracked as authn-sh/authn#264 (v0.8 milestone).

This mirrors the v0.6 sdk-node pattern of shipping SCIM managers as forward-compat against the v0.7 BAPI mirror — consumers get the stable surface now and the runtime gating becomes functional in a later release.

## sdk-php constraint maintenance

Restored for the v0.7 integration window (release-dance tears them back down):

- Composer constraint on \`authn-sh/sdk-php\` widened to \`"dev-main || ^0.6"\` (was \`^0.6\`).
- VCS repository entry pointing at \`https://github.com/authn-sh/sdk-php\` restored.
- \`minimum-stability: dev\` restored.
- \`.github/workflows/ci.yml\` \`Pin authn-sh/sdk-php to dev-main (v0.7 integration)\` step restored.

Team-lead drives the tightening to \`^0.7\` at release dance.

## Test plan

- [x] \`composer test\` — full suite (123 tests, 234 assertions) green.
- [x] \`composer phpstan\` — clean.
- [x] \`composer pint\` — clean.