### PR TITLE
Cut v0.7.0: tighten sdk-php constraint, drop dev-main workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,6 @@ jobs:
           composer require --no-update --no-interaction --dev \
             "orchestra/testbench:${{ matrix.testbench }}"
 
-      # v0.7 integration: pin sdk-php to dev-main while sdk-php@v0.7.0
-      # is not yet on Packagist. The composer.json constraint stays
-      # `"dev-main || ^0.6"`; this step forces resolution to dev-main
-      # so prefer-stable can't pick the older v0.6.0 release.
-      - name: Pin authn-sh/sdk-php to dev-main (v0.7 integration)
-        run: composer require --no-update --no-interaction "authn-sh/sdk-php:dev-main"
-
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.0] — 2026-05-12
 
 ### Added
 
@@ -14,7 +14,7 @@
 
 ### Changed
 
-- Composer constraint on `authn-sh/sdk-php` widened to `dev-main || ^0.6` so CI can resolve against sdk-php main during the v0.7 alpha cycle. The VCS repository entry, `minimum-stability: dev`, and the "Pin authn-sh/sdk-php to dev-main (v0.7 integration)" CI step are restored. All three are torn down again when the release dance cuts v0.7.0.
+- Composer constraint on `authn-sh/sdk-php` tightened to `^0.7` (was `dev-main || ^0.6`). Drops the dev-only VCS repository entry, the `minimum-stability: dev` workaround, and the matching "Pin authn-sh/sdk-php to dev-main" CI step — all of which bridged the v0.7 alpha cycle. `sdk-php@v0.7.0` is now on Packagist.
 
 ## [0.6.0] — 2026-05-12
 

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,11 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "authn-sh/sdk-php": "dev-main || ^0.6",
+        "authn-sh/sdk-php": "^0.7",
         "illuminate/cache": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/authn-sh/sdk-php"
-        }
-    ],
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.10",
@@ -71,9 +65,9 @@
             }
         },
         "branch-alias": {
-            "dev-main": "0.6.x-dev"
+            "dev-main": "0.7.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Step 4 of the v0.7.0 release dance — sdk-php@v0.7.0 is on Packagist now.

- composer.json: `authn-sh/sdk-php` constraint tightened to `^0.7` (was `dev-main || ^0.6`)
- composer.json: drop the VCS repository entry
- composer.json: `minimum-stability` flipped `dev` → `stable`
- composer.json: branch-alias rolled forward `0.6.x-dev` → `0.7.x-dev`
- .github/workflows/ci.yml: drop the 'Pin authn-sh/sdk-php to dev-main' step
- CHANGELOG: `Unreleased` → `[0.7.0] — 2026-05-12`