### PR TITLE
fix(SPL-2): enforce MFA freshness in @authnRequiresMfa directive

### DIFF
--- a/src/AuthnServiceProvider.php
+++ b/src/AuthnServiceProvider.php
@@ -74,7 +74,24 @@ class AuthnServiceProvider extends ServiceProvider
         Blade::if('authnSignedIn', fn (): bool => self::currentClaims() !== null);
         Blade::if('authnSignedOut', fn (): bool => self::currentClaims() === null);
 
-        Blade::if('authnRequiresMfa', fn (): bool => self::currentClaims()?->twoFactorVerified === true);
+        Blade::if(
+            'authnRequiresMfa',
+            function (?int $maxAgeOverride = null): bool {
+                $claims = self::currentClaims();
+                if ($claims === null || $claims->twoFactorVerified !== true) {
+                    return false;
+                }
+                if ($maxAgeOverride !== null) {
+                    $maxAge = $maxAgeOverride;
+                } else {
+                    $configured = config('authn.mfa.max_age_seconds');
+                    $maxAge = is_int($configured) ? $configured : 1800;
+                }
+                $age = $claims->secondFactorAgeSeconds;
+
+                return $age !== null && $age <= $maxAge;
+            },
+        );
 
         Blade::if(
             'authnHasConnectedAccount',

--- a/tests/BladeDirectivesTest.php
+++ b/tests/BladeDirectivesTest.php
@@ -45,6 +45,14 @@ MFA_NOT_VERIFIED
 @endauthnRequiresMfa
 BLADE;
 
+    private const MFA_TIGHT_WINDOW_TEMPLATE = <<<'BLADE'
+@authnRequiresMfa(300)
+MFA_VERIFIED
+@else
+MFA_NOT_VERIFIED
+@endauthnRequiresMfa
+BLADE;
+
     private const CONNECTED_TEMPLATE = <<<'BLADE'
 @authnHasConnectedAccount('google')
 HAS_GOOGLE
@@ -117,6 +125,11 @@ BLADE;
         );
 
         Route::get('/render-mfa-anonymous', fn () => Blade::render(self::MFA_TEMPLATE));
+
+        Route::middleware(AuthenticateWithAuthn::class)->get(
+            '/render-mfa-tight',
+            fn () => Blade::render(self::MFA_TIGHT_WINDOW_TEMPLATE),
+        );
 
         Route::middleware(AuthenticateWithAuthn::class)->get(
             '/render-connected',
@@ -267,6 +280,38 @@ BLADE;
     public function test_authn_requires_mfa_renders_else_branch_on_anonymous_request(): void
     {
         $body = $this->get('/render-mfa-anonymous')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_renders_else_branch_when_second_factor_age_exceeds_default_max_age(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [60, 3600]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_honours_configured_max_age_seconds(): void
+    {
+        config(['authn.mfa.max_age_seconds' => 60]);
+
+        $jwt = $this->env->signJwt(['fva' => [10, 120]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa')->getContent();
+
+        $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
+        $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);
+    }
+
+    public function test_authn_requires_mfa_argument_overrides_configured_max_age(): void
+    {
+        $jwt = $this->env->signJwt(['fva' => [10, 500]]);
+
+        $body = $this->withHeader('Authorization', "Bearer {$jwt}")->get('/render-mfa-tight')->getContent();
 
         $this->assertStringContainsString('MFA_NOT_VERIFIED', (string) $body);
         $this->assertStringNotContainsString('MFA_VERIFIED', (string) $body);


### PR DESCRIPTION
Closes #25.

## Summary

- `@authnRequiresMfa` now mirrors the `RequiresMfa` route middleware: returns false unless `secondFactorAgeSeconds` is non-null AND ≤ configured `authn.mfa.max_age_seconds` (default 1800).
- Optional template argument override, matching the `authn.requires_mfa:<seconds>` middleware alias (`@authnRequiresMfa(300)`).
- Three new Pest tests: stale-MFA, custom config max age, argument override.

## Why

Pre-fix, a stale-but-verified second factor would pass the directive while failing the middleware — fail-open UI rendering for up to ~30 min after factor-two would have redirected on a real route hit.

## Test plan

- [x] `composer pint`
- [x] `composer phpstan`
- [x] `composer test` — 126 tests pass